### PR TITLE
Win32/Win64库文件冲突

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/slua_unreal.Build.cs
+++ b/Plugins/slua_unreal/Source/slua_unreal/slua_unreal.Build.cs
@@ -51,9 +51,13 @@ public class slua_unreal : ModuleRules
                     break;
                 }
             case UnrealTargetPlatform.Win32:
-            case UnrealTargetPlatform.Win64:
                 {
                     PublicLibraryPaths.Add(Path.Combine(externalLib, "Win32"));
+                    PublicAdditionalLibraries.Add("lua.lib");
+                    break;
+                }
+            case UnrealTargetPlatform.Win64:
+                {
                     PublicLibraryPaths.Add(Path.Combine(externalLib, "Win64"));
                     PublicAdditionalLibraries.Add("lua.lib");
                     break;


### PR DESCRIPTION
将Win32和Win64的静态库搜索路径分开以避免发送链接冲突