### PR TITLE
添加缺失的模块依赖

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/slua_unreal.Build.cs
+++ b/Plugins/slua_unreal/Source/slua_unreal/slua_unreal.Build.cs
@@ -75,7 +75,7 @@ public class slua_unreal : ModuleRules
             new string[]
             {
                 "Core",
-				
+				"UMG",
 				// ... add other public dependencies that you statically link with here ...
 			}
             );


### PR DESCRIPTION
解决UE 4.20下可能出现的"Blueprint/WidgetTree.h"头文件包含不到的问题