### PR TITLE
doBuffer/doString/doFile方法增加参数，可以提供运行环境，以做全局变量隔离

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaState.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaState.h
@@ -61,13 +61,13 @@ namespace slua {
         virtual void close();
 
         // execute lua string
-        LuaVar doString(const char* str);
+        LuaVar doString(const char* str, LuaVar* pEnv = nullptr);
         // execute bytes buffer and named buffer to chunk
-        LuaVar doBuffer(const uint8* buf,uint32 len, const char* chunk);
+        LuaVar doBuffer(const uint8* buf,uint32 len, const char* chunk, LuaVar* pEnv = nullptr);
         // load file and execute it
         // file how to loading depend on load delegation
         // see setLoadFileDelegate function
-        LuaVar doFile(const char* fn);
+        LuaVar doFile(const char* fn, LuaVar* pEnv = nullptr);
 
        
         // call function that specified by key


### PR DESCRIPTION
pEnv参数可选，以让所有非local变量保存在这个独立提供的env table里面。
默认nullptr，则直接使用_G而不使用独立运行环境。