### PR TITLE
增加宏REG_EXTENSION_METHOD_LAMBDA可以直接绑定lambda函数为Lua扩展函数

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaCppBinding.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaCppBinding.h
@@ -259,7 +259,7 @@ namespace slua {
 			return LambdaPrototype<ReturnType, ArgType ...>();
 		}
 
-		typedef decltype(DeducePrototype(&LambdaType::operator())) SignatureType;
+		typedef decltype(DeducePrototype(&LambdaType::operator())) Prototype;
 	};
 
 
@@ -388,7 +388,7 @@ namespace slua {
 
 	#define REG_EXTENSION_METHOD_LAMBDA(U,N,L) { \
 		auto lambda = L; \
-		using BindType = LuaLambdaBinding<decltype(lambda)>::SignatureType; \
+		using BindType = LuaLambdaBinding<decltype(lambda)>::Prototype; \
 		BindType::Func = lambda; \
 		LuaObject::addExtensionMethod(U::StaticClass(), N, BindType::LuaCFunction, true); \
 	}

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaCppBinding.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaCppBinding.h
@@ -268,7 +268,6 @@ namespace slua {
 		typedef decltype(DeducePrototype(&LambdaType::operator())) Prototype;
 	};
 
-
     struct SLUA_UNREAL_API LuaClass {
         LuaClass(lua_CFunction reg);
         static void reg(lua_State* L);
@@ -392,11 +391,11 @@ namespace slua {
     #define REG_EXTENSION_METHOD_IMP_STATIC(U,N,BODY) { \
         LuaObject::addExtensionMethod(U::StaticClass(),N,[](lua_State* L)->int BODY,true); }
 
-	#define REG_EXTENSION_METHOD_LAMBDA(U,N,L) { \
-		static auto lambda = L; \
+	#define REG_EXTENSION_METHOD_LAMBDA(U,N, Static, ...) { \
+		static auto lambda = __VA_ARGS__; \
 		using BindType = LuaLambdaBinding<decltype(lambda)>::Prototype; \
 		BindType::Func = &lambda; \
-		LuaObject::addExtensionMethod(U::StaticClass(), N, BindType::LuaCFunction, true); \
+		LuaObject::addExtensionMethod(U::StaticClass(), N, BindType::LuaCFunction, Static); \
 	}
     
 }


### PR DESCRIPTION
可以直接绑定任意Lambda函数，支持任意参数和返回值，自动完成参数、返回值同Lua之间的相互转化。用例：

	
    REG_EXTENSION_METHOD_LAMBDA(UResourceManager, "LoadAsset", [](const FString& Path)
    {
        return UGameGlobal::GetInstanceObject<UResourceManager>()->LoadAsset(Path); 
    });