### PR TITLE
ArgOperator增加对TFunction的判断，以允许由Lua侧直接传递function作为函数参数至C++侧

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaArray.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaArray.cpp
@@ -13,7 +13,6 @@
 
 #include "LuaArray.h"
 #include "LuaObject.h"
-#include "LuaCppBinding.h"
 #include <string>
 #include "SluaLib.h"
 

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -27,7 +27,6 @@
 #include "LuaArray.h"
 #include "LuaMap.h"
 #include "Log.h"
-#include "LuaCppBinding.h"
 #include "LuaState.h"
 #include "LuaWrapper.h"
 #include "LuaEnums.h"

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
@@ -25,7 +25,6 @@
 #include <map>
 #include "LuaWrapper.h"
 #include "LuaEnums.h"
-#include "LuaCppBinding.h"
 #include "LuaArray.h"
 #include "LuaMap.h"
 #include "LuaSocketWrap.h"

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaCppBindingPost.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaCppBindingPost.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "LuaVar.h"
+
+namespace slua
+{
+	template<typename T>
+	inline static T resultCast(LuaVar&& Var, typename std::enable_if<!std::is_void<T>::value, int>::type = 0)
+	{
+		return Var.castTo<T>();
+	}
+
+	template<typename T>
+	inline static T resultCast(LuaVar&& Var, typename std::enable_if<std::is_void<T>::value, int>::type = 0) {}
+
+	template<typename CallableType, typename ReturnType, typename ... ArgTypes>
+	typename CallableExpand<CallableType, ReturnType, ArgTypes...>::TFunctionType
+	CallableExpand<CallableType, ReturnType, ArgTypes...>::makeTFunctionProxy(lua_State* L, int p)
+	{
+		LuaVar func(L, p);
+		return [=](ArgTypes&& ... args) mutable -> ReturnType
+		{
+			LuaVar result = func.call(std::forward<ArgTypes>(args) ...);
+			return resultCast<ReturnType>(std::move(result));
+		};
+	}
+}


### PR DESCRIPTION
在C++侧为Lua提供扩展函数时，允许使用TFunction作为参数，在lua侧直接传递function即可使用。用例：

```c++
REG_EXTENSION_METHOD_LAMBDA(UResourceManager, "LoadAssetAsync", true, [](const FString& Path, TFunction<void(UObject*)>&& Callback)
{
    UGameGlobal::GetInstanceObject<UResourceManager>()->LoadAssetAsync(Path, MoveTemp(Callback));
});
```

```lua
import("ResourceManager").LoadAssetAsync("/Game/MyTexture.MyTexture",
    function(texture)
        local brush = CPP.WidgetBlueprintLibrary.MakeBrushFromTexture(texture, 0, 0)
        ref.Image.SetBrush(brush)
    end)
```
