### PR TITLE
在 actor 中使用 "PrimaryActorTick.bCanEverTick" 代替 "bCanEverTick" 

### DIFF
--- a/Content/Lua/LuaActor.lua
+++ b/Content/Lua/LuaActor.lua
@@ -4,7 +4,7 @@ local actor={}
 
 -- override event from blueprint
 function actor:ReceiveBeginPlay()
-    self.bCanEverTick = true
+    self.PrimaryActorTick.bCanEverTick = true
     -- set bCanBeDamaged property in parent
     self.bCanBeDamaged = false
     print("actor:ReceiveBeginPlay")

--- a/Content/Lua/LuaBpActor.lua
+++ b/Content/Lua/LuaBpActor.lua
@@ -3,7 +3,7 @@ local actor={}
 
 -- override event from blueprint
 function actor:ReceiveBeginPlay()
-    self.bCanEverTick = true
+    self.PrimaryActorTick.bCanEverTick = true
     -- set bCanBeDamaged property in parent
     self.bCanBeDamaged = false
     print("bpactor:ReceiveBeginPlay")

--- a/Content/Lua/Map2Actor.lua
+++ b/Content/Lua/Map2Actor.lua
@@ -3,7 +3,7 @@
 local actor={}
 -- override event from blueprint
 function actor:ReceiveBeginPlay()
-    self.bCanEverTick = true
+    self.PrimaryActorTick.bCanEverTick = true
     -- set bCanBeDamaged property in parent
     self.bCanBeDamaged = false
     print("actor:ReceiveBeginPlay")


### PR DESCRIPTION
use "PrimaryActorTick.bCanEverTick" instead of "bCanEverTick" in actor.