### PR TITLE
解决LuaUserWidget tick的bug

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaBase.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaBase.cpp
@@ -133,12 +133,10 @@ namespace slua {
 		if (!luaSelfTable.isTable())
 			return false;
 
-		bool tickEnabled = luaSelfTable.getFromTable<bool>(tickFlag, rawget);
-
-		if (tickEnabled && luaSelfTable.isTable()) {
+		if (luaSelfTable.isTable()) {
 			tickFunction = luaSelfTable.getFromTable<slua::LuaVar>("Tick", true);
-			return tickEnabled;
 		}
-		return false;
+
+		return luaSelfTable.getFromTable<bool>(tickFlag, rawget);
 	}
 }

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaUserWidget.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaUserWidget.cpp
@@ -32,9 +32,16 @@ void ULuaUserWidget::NativeDestruct() {
 
 void ULuaUserWidget::NativeTick(const FGeometry & MyGeometry, float InDeltaTime)
 {
-	// store current tick parameter MyGeometry
-	currentGeometry = MyGeometry;
-	tick(InDeltaTime);
+	if (ensureMsgf(GetDesiredTickFrequency() != EWidgetTickFrequency::Never, TEXT("SObjectWidget and UUserWidget have mismatching tick states or UUserWidget::NativeTick was called manually (Never do this)")))
+	{
+		GInitRunaway();
+		TickActionsAndAnimation(MyGeometry, InDeltaTime);
+
+		if (bHasScriptImplementedTick) {
+			currentGeometry = MyGeometry;
+			tick(InDeltaTime);
+		}
+	}
 }
 
 void ULuaUserWidget::ProcessEvent(UFunction * func, void * params)
@@ -46,5 +53,5 @@ void ULuaUserWidget::ProcessEvent(UFunction * func, void * params)
 
 void ULuaUserWidget::superTick()
 {
-	Super::NativeTick(currentGeometry, deltaTime);
+	Super::Tick(currentGeometry, deltaTime);
 }


### PR DESCRIPTION
解决问题:当LuaUserWidget对应的lua脚本中实现了Tick函数, 但是bHasScriptImplementedTick在Construct函数里面设置为false时, tickFunction不会进行初始化, 但是后续通过逻辑变成true后, 会执行Userwidget里面的Tick函数, 但是由于UserWidget的tick的第一个参数是FGeometry, 会把lua脚本中函数Tick的self变成FGeometry