### PR TITLE
删除冗余代码

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/SluaLib.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/SluaLib.cpp
@@ -54,9 +54,6 @@ namespace slua {
 
     template<typename T>
     UClass* loadClassT(const char* cls) {
-        TArray<FStringFormatArg> Args;
-        Args.Add(UTF8_TO_TCHAR(cls));
-
 		FString path(UTF8_TO_TCHAR(cls));
 		int32 index;
 		if (!path.FindChar(TCHAR('\''),index)) {


### PR DESCRIPTION
TArray<FStringFormatArg> Args;
Args.Add(UTF8_TO_TCHAR(cls));

以前这个写法也会有问题，UTF8_TO_TCHAR(cls)会生成TStringConversion的临时对象，并返回TChar*，但是它出了作用域就会被销毁。Args.Add(FStringFormatArg)会把TChar*转移给FStringFormatArg对象，但是这里并没有做拷贝操作。TStringConversion出了作用域后，FStringFormatArg就会指向一个未知的内存块了。