### PR TITLE
fix invalid uobject access in LuaReference

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaReference.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaReference.cpp
@@ -93,7 +93,7 @@ namespace NS_SLUA {
 			{
 				void* value = container?p->ContainerPtrToValuePtr<void>(base, n):base;
 				UObject* obj = p->GetObjectPropertyValue(value);
-				if (obj)
+				if (obj && obj->IsValidLowLevel())
 				{
 					UObject* newobj = obj;
 					collector.AddReferencedObject(newobj);


### PR DESCRIPTION
In some condition, luaarray and luamap still exists, but uobject it references is freed.