### PR TITLE
fix invalid access of LuaArray and LuaMap

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaArray.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaArray.cpp
@@ -97,7 +97,7 @@ namespace NS_SLUA {
 
         // if empty or owner object had been collected
 		// AddReferencedObject will auto null propObj
-        if(num()==0 || (!shouldFree && !propObj)) return;
+        if((!shouldFree && !propObj) || num()==0) return;
 		for (int n = num() - 1; n >= 0; n--) {
             void* ptr = getRawPtr(n);
 			// if AddReferencedObject collect obj

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaMap.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaMap.cpp
@@ -116,7 +116,7 @@ namespace NS_SLUA {
 
 		// if empty or owner object had been collected
 		// AddReferencedObject will auto null propObj
-		if(num()<=0 || (!shouldFree && !propObj)) return;
+		if((!shouldFree && !propObj) || num()<=0) return;
 		bool rehash = false;
 		// for each valid entry of map
 		for (int index = helper.GetMaxIndex()-1;index>=0; index--) {


### PR DESCRIPTION
If propObj of LuaArray and LuaMap is deleted, `num()` will access invalid memory, so check propObj first.