### PR TITLE
feat(slua_unreal) : Fix calling rpc function crash 

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -496,7 +496,7 @@ namespace NS_SLUA {
 		const bool bHasReturnParam = func->ReturnValueOffset != MAX_uint16;
 		uint8* ReturnValueAddress = bHasReturnParam ? ((uint8*)params + func->ReturnValueOffset) : nullptr;
         
-        #if ENGINE_MINOR_VERSION == 23 && !PLATFORM_WINDOWS
+        #if ENGINE_MINOR_VERSION >= 23 && !PLATFORM_WINDOWS
             FNewFrame NewStack(obj, func, params, NULL, func->Children);
         
             if (func->ReturnValueOffset != MAX_uint16) {
@@ -542,7 +542,7 @@ namespace NS_SLUA {
         
             FFrame *frame = (FFrame *)&NewStack;
             func->Invoke(obj, *frame, ReturnValueAddress);
-        #elif ENGINE_MINOR_VERSION > 21
+        #elif ENGINE_MINOR_VERSION > 21 && ENGINE_MINOR_VERSION < 25
             FFrame NewStack(obj, func, params, NULL, func->Children);
             NewStack.OutParms = nullptr;
             if (func->ReturnValueOffset != MAX_uint16) {

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -496,14 +496,95 @@ namespace NS_SLUA {
 		const bool bHasReturnParam = func->ReturnValueOffset != MAX_uint16;
 		uint8* ReturnValueAddress = bHasReturnParam ? ((uint8*)params + func->ReturnValueOffset) : nullptr;
         
-        #if ENGINE_MINOR_VERSION>22 && !PLATFORM_WINDOWS
+        #if ENGINE_MINOR_VERSION == 23 && !PLATFORM_WINDOWS
             FNewFrame NewStack(obj, func, params, NULL, func->Children);
-            NewStack.OutParms = nullptr;
+        
+            if (func->ReturnValueOffset != MAX_uint16) {
+                UProperty* ReturnProperty = func->GetReturnProperty();
+                if (ensure(ReturnProperty)) {
+                    FOutParmRec* RetVal = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
+
+                    /* Our context should be that we're in a variable assignment to the return value, so ensure that we have a valid property to return to */
+                    RetVal->PropAddr = (uint8*)FMemory_Alloca(ReturnProperty->GetSize());
+                    RetVal->Property = ReturnProperty;
+                    NewStack.OutParms = RetVal;
+                }
+            }
+
+            NewStack.Locals = params;
+            FOutParmRec** LastOut = &NewStack.OutParms;
+
+            for (UProperty* Property = (UProperty*)func->Children; Property!=nullptr; Property = (UProperty*)Property->Next){
+                if (Property->PropertyFlags & CPF_OutParm){
+
+                    CA_SUPPRESS(6263)
+                        FOutParmRec* Out = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
+                    // set the address and property in the out param info
+                    // warning: Stack.MostRecentPropertyAddress could be NULL for optional out parameters
+                    // if that's the case, we use the extra memory allocated for the out param in the function's locals
+                    // so there's always a valid address
+                    Out->PropAddr = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
+                    Out->Property = Property;
+
+                    // add the new out param info to the stack frame's linked list
+                    if (*LastOut) {
+                        (*LastOut)->NextOutParm = Out;
+                        LastOut = &(*LastOut)->NextOutParm;
+                    } else {
+                        *LastOut = Out;
+                    }
+                } else {
+                    // copy the result of the expression for this parameter into the appropriate part of the local variable space
+                    uint8* Param = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
+                    Property->InitializeValue_InContainer(NewStack.Locals);
+                }
+            }
+        
             FFrame *frame = (FFrame *)&NewStack;
             func->Invoke(obj, *frame, ReturnValueAddress);
-        #else
+        #elif ENGINE_MINOR_VERSION > 21
             FFrame NewStack(obj, func, params, NULL, func->Children);
             NewStack.OutParms = nullptr;
+            if (func->ReturnValueOffset != MAX_uint16) {
+                UProperty* ReturnProperty = func->GetReturnProperty();
+                if (ensure(ReturnProperty)) {
+                   FOutParmRec* RetVal = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
+
+                   /* Our context should be that we're in a variable assignment to the return value, so ensure that we have a valid property to return to */
+                   RetVal->PropAddr = (uint8*)FMemory_Alloca(ReturnProperty->GetSize());
+                   RetVal->Property = ReturnProperty;
+                   NewStack.OutParms = RetVal;
+                }
+            }
+
+            NewStack.Locals = params;
+            FOutParmRec** LastOut = &NewStack.OutParms;
+
+            for (UProperty* Property = (UProperty*)func->Children; Property!=nullptr; Property = (UProperty*)Property->Next){
+               if (Property->PropertyFlags & CPF_OutParm){
+
+                   CA_SUPPRESS(6263)
+                       FOutParmRec* Out = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
+                   // set the address and property in the out param info
+                   // warning: Stack.MostRecentPropertyAddress could be NULL for optional out parameters
+                   // if that's the case, we use the extra memory allocated for the out param in the function's locals
+                   // so there's always a valid address
+                   Out->PropAddr = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
+                   Out->Property = Property;
+
+                   // add the new out param info to the stack frame's linked list
+                   if (*LastOut) {
+                       (*LastOut)->NextOutParm = Out;
+                       LastOut = &(*LastOut)->NextOutParm;
+                   } else {
+                       *LastOut = Out;
+                   }
+               } else {
+                   // copy the result of the expression for this parameter into the appropriate part of the local variable space
+                   uint8* Param = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
+                   Property->InitializeValue_InContainer(NewStack.Locals);
+               }
+            }
             func->Invoke(obj, NewStack, ReturnValueAddress);
         #endif
 	}

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -495,17 +495,17 @@ namespace NS_SLUA {
 		// call rpc without outparams
 		const bool bHasReturnParam = func->ReturnValueOffset != MAX_uint16;
 		uint8* ReturnValueAddress = bHasReturnParam ? ((uint8*)params + func->ReturnValueOffset) : nullptr;
-    #if PLATFORM_WINDOWS
-        FFrame NewStack(obj, func, params, NULL, func->Children);
-        NewStack.OutParms = nullptr;
-        func->Invoke(obj, NewStack, ReturnValueAddress);
-    #else
-        FNewFrame NewStack(obj, func, params, NULL, func->Children);
-        NewStack.OutParms = nullptr;
-        FFrame *frame = (FFrame *)&NewStack;
-        func->Invoke(obj, *frame, ReturnValueAddress);
-    #endif
         
+        #if ENGINE_MINOR_VERSION>22 && !PLATFORM_WINDOWS
+            FNewFrame NewStack(obj, func, params, NULL, func->Children);
+            NewStack.OutParms = nullptr;
+            FFrame *frame = (FFrame *)&NewStack;
+            func->Invoke(obj, *frame, ReturnValueAddress);
+        #else
+            FFrame NewStack(obj, func, params, NULL, func->Children);
+            NewStack.OutParms = nullptr;
+            func->Invoke(obj, NewStack, ReturnValueAddress);
+        #endif
 	}
 
 	void LuaObject::callUFunction(lua_State* L, UObject* obj, UFunction* func, uint8* params) {

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -498,93 +498,57 @@ namespace NS_SLUA {
         
         #if ENGINE_MINOR_VERSION >= 23 && !PLATFORM_WINDOWS
             FNewFrame NewStack(obj, func, params, NULL, func->Children);
+        #else
+            FFrame NewStack(obj, func, params, NULL, func->Children);
+        #endif
         
-            if (func->ReturnValueOffset != MAX_uint16) {
-                UProperty* ReturnProperty = func->GetReturnProperty();
-                if (ensure(ReturnProperty)) {
-                    FOutParmRec* RetVal = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
+        #if ENGINE_MINOR_VERSION < 25
+        if (func->ReturnValueOffset != MAX_uint16) {
+            UProperty* ReturnProperty = func->GetReturnProperty();
+            if (ensure(ReturnProperty)) {
+                FOutParmRec* RetVal = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
 
-                    /* Our context should be that we're in a variable assignment to the return value, so ensure that we have a valid property to return to */
-                    RetVal->PropAddr = (uint8*)FMemory_Alloca(ReturnProperty->GetSize());
-                    RetVal->Property = ReturnProperty;
-                    NewStack.OutParms = RetVal;
-                }
+                /* Our context should be that we're in a variable assignment to the return value, so ensure that we have a valid property to return to */
+                RetVal->PropAddr = (uint8*)FMemory_Alloca(ReturnProperty->GetSize());
+                RetVal->Property = ReturnProperty;
+                NewStack.OutParms = RetVal;
             }
+        }
 
-            NewStack.Locals = params;
-            FOutParmRec** LastOut = &NewStack.OutParms;
+        NewStack.Locals = params;
+        FOutParmRec** LastOut = &NewStack.OutParms;
 
-            for (UProperty* Property = (UProperty*)func->Children; Property!=nullptr; Property = (UProperty*)Property->Next){
-                if (Property->PropertyFlags & CPF_OutParm){
+        for (UProperty* Property = (UProperty*)func->Children; Property!=nullptr; Property = (UProperty*)Property->Next){
+            if (Property->PropertyFlags & CPF_OutParm){
 
-                    CA_SUPPRESS(6263)
-                        FOutParmRec* Out = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
-                    // set the address and property in the out param info
-                    // warning: Stack.MostRecentPropertyAddress could be NULL for optional out parameters
-                    // if that's the case, we use the extra memory allocated for the out param in the function's locals
-                    // so there's always a valid address
-                    Out->PropAddr = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
-                    Out->Property = Property;
+                CA_SUPPRESS(6263)
+                    FOutParmRec* Out = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
+                // set the address and property in the out param info
+                // warning: Stack.MostRecentPropertyAddress could be NULL for optional out parameters
+                // if that's the case, we use the extra memory allocated for the out param in the function's locals
+                // so there's always a valid address
+                Out->PropAddr = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
+                Out->Property = Property;
 
-                    // add the new out param info to the stack frame's linked list
-                    if (*LastOut) {
-                        (*LastOut)->NextOutParm = Out;
-                        LastOut = &(*LastOut)->NextOutParm;
-                    } else {
-                        *LastOut = Out;
-                    }
+                // add the new out param info to the stack frame's linked list
+                if (*LastOut) {
+                    (*LastOut)->NextOutParm = Out;
+                    LastOut = &(*LastOut)->NextOutParm;
                 } else {
-                    // copy the result of the expression for this parameter into the appropriate part of the local variable space
-                    uint8* Param = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
-                    Property->InitializeValue_InContainer(NewStack.Locals);
+                    *LastOut = Out;
                 }
+            } else {
+                // copy the result of the expression for this parameter into the appropriate part of the local variable space
+                uint8* Param = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
+                Property->InitializeValue_InContainer(NewStack.Locals);
             }
-        
+        }
+        #endif
+    
+        #if ENGINE_MINOR_VERSION >= 23 && !PLATFORM_WINDOWS
             FFrame *frame = (FFrame *)&NewStack;
             func->Invoke(obj, *frame, ReturnValueAddress);
-        #elif ENGINE_MINOR_VERSION > 21 && ENGINE_MINOR_VERSION < 25
-            FFrame NewStack(obj, func, params, NULL, func->Children);
-            NewStack.OutParms = nullptr;
-            if (func->ReturnValueOffset != MAX_uint16) {
-                UProperty* ReturnProperty = func->GetReturnProperty();
-                if (ensure(ReturnProperty)) {
-                   FOutParmRec* RetVal = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
-
-                   /* Our context should be that we're in a variable assignment to the return value, so ensure that we have a valid property to return to */
-                   RetVal->PropAddr = (uint8*)FMemory_Alloca(ReturnProperty->GetSize());
-                   RetVal->Property = ReturnProperty;
-                   NewStack.OutParms = RetVal;
-                }
-            }
-
-            NewStack.Locals = params;
-            FOutParmRec** LastOut = &NewStack.OutParms;
-
-            for (UProperty* Property = (UProperty*)func->Children; Property!=nullptr; Property = (UProperty*)Property->Next){
-               if (Property->PropertyFlags & CPF_OutParm){
-
-                   CA_SUPPRESS(6263)
-                       FOutParmRec* Out = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
-                   // set the address and property in the out param info
-                   // warning: Stack.MostRecentPropertyAddress could be NULL for optional out parameters
-                   // if that's the case, we use the extra memory allocated for the out param in the function's locals
-                   // so there's always a valid address
-                   Out->PropAddr = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
-                   Out->Property = Property;
-
-                   // add the new out param info to the stack frame's linked list
-                   if (*LastOut) {
-                       (*LastOut)->NextOutParm = Out;
-                       LastOut = &(*LastOut)->NextOutParm;
-                   } else {
-                       *LastOut = Out;
-                   }
-               } else {
-                   // copy the result of the expression for this parameter into the appropriate part of the local variable space
-                   uint8* Param = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
-                   Property->InitializeValue_InContainer(NewStack.Locals);
-               }
-            }
+        #else
             func->Invoke(obj, NewStack, ReturnValueAddress);
         #endif
 	}

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -495,9 +495,17 @@ namespace NS_SLUA {
 		// call rpc without outparams
 		const bool bHasReturnParam = func->ReturnValueOffset != MAX_uint16;
 		uint8* ReturnValueAddress = bHasReturnParam ? ((uint8*)params + func->ReturnValueOffset) : nullptr;
-		FFrame NewStack(obj, func, params, NULL, func->Children);
-		NewStack.OutParms = nullptr;
-		func->Invoke(obj, NewStack, ReturnValueAddress);
+    #if PLATFORM_WINDOWS
+        FFrame NewStack(obj, func, params, NULL, func->Children);
+        NewStack.OutParms = nullptr;
+        func->Invoke(obj, NewStack, ReturnValueAddress);
+    #else
+        FNewFrame NewStack(obj, func, params, NULL, func->Children);
+        NewStack.OutParms = nullptr;
+        FFrame *frame = (FFrame *)&NewStack;
+        func->Invoke(obj, *frame, ReturnValueAddress);
+    #endif
+        
 	}
 
 	void LuaObject::callUFunction(lua_State* L, UObject* obj, UFunction* func, uint8* params) {

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -503,46 +503,48 @@ namespace NS_SLUA {
         #endif
         
         #if ENGINE_MINOR_VERSION < 25
-        if (func->ReturnValueOffset != MAX_uint16) {
-            UProperty* ReturnProperty = func->GetReturnProperty();
-            if (ensure(ReturnProperty)) {
-                FOutParmRec* RetVal = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
+            if (func->ReturnValueOffset != MAX_uint16) {
+                UProperty* ReturnProperty = func->GetReturnProperty();
+                if (ensure(ReturnProperty)) {
+                    FOutParmRec* RetVal = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
 
-                /* Our context should be that we're in a variable assignment to the return value, so ensure that we have a valid property to return to */
-                RetVal->PropAddr = (uint8*)FMemory_Alloca(ReturnProperty->GetSize());
-                RetVal->Property = ReturnProperty;
-                NewStack.OutParms = RetVal;
-            }
-        }
-
-        NewStack.Locals = params;
-        FOutParmRec** LastOut = &NewStack.OutParms;
-
-        for (UProperty* Property = (UProperty*)func->Children; Property!=nullptr; Property = (UProperty*)Property->Next){
-            if (Property->PropertyFlags & CPF_OutParm){
-
-                CA_SUPPRESS(6263)
-                    FOutParmRec* Out = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
-                // set the address and property in the out param info
-                // warning: Stack.MostRecentPropertyAddress could be NULL for optional out parameters
-                // if that's the case, we use the extra memory allocated for the out param in the function's locals
-                // so there's always a valid address
-                Out->PropAddr = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
-                Out->Property = Property;
-
-                // add the new out param info to the stack frame's linked list
-                if (*LastOut) {
-                    (*LastOut)->NextOutParm = Out;
-                    LastOut = &(*LastOut)->NextOutParm;
-                } else {
-                    *LastOut = Out;
+                    /* Our context should be that we're in a variable assignment to the return value, so ensure that we have a valid property to return to */
+                    RetVal->PropAddr = (uint8*)FMemory_Alloca(ReturnProperty->GetSize());
+                    RetVal->Property = ReturnProperty;
+                    NewStack.OutParms = RetVal;
                 }
-            } else {
-                // copy the result of the expression for this parameter into the appropriate part of the local variable space
-                uint8* Param = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
-                Property->InitializeValue_InContainer(NewStack.Locals);
             }
-        }
+
+            NewStack.Locals = params;
+            FOutParmRec** LastOut = &NewStack.OutParms;
+
+            for (UProperty* Property = (UProperty*)func->Children; Property!=nullptr; Property = (UProperty*)Property->Next){
+                if (Property->PropertyFlags & CPF_OutParm){
+
+                    CA_SUPPRESS(6263)
+                        FOutParmRec* Out = (FOutParmRec*)FMemory_Alloca(sizeof(FOutParmRec));
+                    // set the address and property in the out param info
+                    // warning: Stack.MostRecentPropertyAddress could be NULL for optional out parameters
+                    // if that's the case, we use the extra memory allocated for the out param in the function's locals
+                    // so there's always a valid address
+                    Out->PropAddr = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
+                    Out->Property = Property;
+
+                    // add the new out param info to the stack frame's linked list
+                    if (*LastOut) {
+                        (*LastOut)->NextOutParm = Out;
+                        LastOut = &(*LastOut)->NextOutParm;
+                    } else {
+                        *LastOut = Out;
+                    }
+                } else {
+                    // copy the result of the expression for this parameter into the appropriate part of the local variable space
+                    uint8* Param = Property->ContainerPtrToValuePtr<uint8>(NewStack.Locals);
+                    Property->InitializeValue_InContainer(NewStack.Locals);
+                }
+            }
+        #else
+            NewStack.OutParms = nullptr;
         #endif
     
         #if ENGINE_MINOR_VERSION >= 23 && !PLATFORM_WINDOWS

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaObject.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaObject.h
@@ -925,7 +925,7 @@ namespace NS_SLUA {
 	}
 }
 
-#if !PLATFORM_WINDOWS
+#if (!PLATFORM_WINDOWS) && (ENGINE_MINOR_VERSION>21)
 struct FNewFrame : public FOutputDevice
     {
     public:

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaObject.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaObject.h
@@ -925,7 +925,7 @@ namespace NS_SLUA {
 	}
 }
 
-#if (!PLATFORM_WINDOWS) && (ENGINE_MINOR_VERSION>21)
+#if !PLATFORM_WINDOWS && ENGINE_MINOR_VERSION >= 23
 struct FNewFrame : public FOutputDevice
     {
     public:


### PR DESCRIPTION
1. fix the UE 4.22 - 4.24 crash caused by null pointer exception.
2. fix UE 4.23 running on MacOS  occurs the compile error(Undefined Sysmbol : FFrame::~FFrame()) since the FFrame class missed the output macro.