### PR TITLE
修正几处代码问题

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaReference.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaReference.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 #include "LuaReference.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 namespace NS_SLUA {
 	namespace LuaReference {

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
@@ -170,6 +170,7 @@ namespace NS_SLUA {
 		, stackCount(0)
 		, si(0)
 		, deadLoopCheck(nullptr)
+		, latentDelegate(nullptr)
 		, currentCallStack(0)
     {
         if(name) stateName=UTF8_TO_TCHAR(name);

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaDelegate.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaDelegate.h
@@ -16,6 +16,7 @@
 #include "CoreMinimal.h"
 #include "lua/lua.hpp"
 #include "SluaUtil.h"
+#include "LuaObject.h"
 #include "LuaDelegate.generated.h"
 
 namespace NS_SLUA {


### PR DESCRIPTION
LuaDelegate.h
bUnityBuild关闭后缺失头文件引用

LuaReference.cpp
不引Version.h的话ENGINE_MAJOR_VERSION和ENGINE_MINOR_VERSION宏在本文件未定义

LuaState.cpp
latentDelegate成员变量未初始化


