### PR TITLE
拓展LuaState::set支持修改一个已经存在的值 & 修复struct传递到Lua中导致的内存泄露

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
@@ -777,11 +777,31 @@ namespace NS_SLUA {
 				if (!right.IsEmpty() && !lua_istable(L, -1))
 					return false;
 
-				if (lua_istable(L, -1) && right.IsEmpty()) {
-					lua_pushstring(L, TCHAR_TO_UTF8(*left));
-					v.push(L);
-					lua_rawset(L, -3);
-					return true;
+				if (right.IsEmpty())
+				{
+					if (
+						(lua_isboolean(L, -1) && v.isBool()) ||
+						(lua_isnumber(L, -1) && v.isNumber()) ||
+						(lua_isinteger(L, -1) && v.isInt()) ||
+						(lua_isstring(L, -1) && v.isString()) ||
+						(lua_istable(L, -1) && v.isTable()) ||
+						(lua_isfunction(L, -1) && v.isFunction()) ||
+						(lua_isuserdata(L, -1) && v.isUserdata("UObject")) ||
+						(lua_islightuserdata(L, -1) && v.isLightUserdata())
+					)
+					{
+						lua_pop(L, 1);
+					}
+
+					if (lua_istable(L, -1))
+					{
+						lua_pushstring(L, TCHAR_TO_UTF8(*left));
+						v.push(L);
+						lua_rawset(L, -3);
+						return true;
+					}
+
+					return false;
 				}
 			}
 			path = right;

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
@@ -838,7 +838,10 @@ namespace NS_SLUA {
 	FDeadLoopCheck::~FDeadLoopCheck()
 	{
 		Stop();
-		thread->WaitForCompletion();
+		if (thread != nullptr)
+		{
+			thread->WaitForCompletion();
+		}
 		SafeDelete(thread);
 	}
 

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaObject.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaObject.h
@@ -522,7 +522,10 @@ namespace NS_SLUA {
 				uint8* buf = (uint8*)FMemory::Malloc(size);
 				uss->InitializeStruct(buf);
 				uss->CopyScriptStruct(buf, v);
-				cacheObj(L, void_cast(v));
+				if (flag & UD_AUTOGC)
+				{
+					delete v;
+				}
 				return push(L, new LuaStruct(buf, size, uss));
 			}
 			NewUD(T, v, flag);

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaState.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaState.h
@@ -207,6 +207,12 @@ namespace NS_SLUA
 
         // tell Engine which objs should be referenced
         virtual void AddReferencedObjects(FReferenceCollector &Collector) override;
+
+        virtual FString GetReferencerName() const override
+        {
+            return FString("LuaState");
+        };
+        
         static int pushErrorHandler(lua_State *L);
 #if (ENGINE_MINOR_VERSION >= 23) || (ENGINE_MAJOR_VERSION > 4)
         virtual void OnUObjectArrayShutdown() override;


### PR DESCRIPTION
当前的set函数中，如果一个值已经存在，会设置失败。拓展之后对已经存在的值也能设置上，方便Runtime的时候动态设置一些变量，减少打包次数以及用于Debug。
当传递一个const引用的struct时，会先new一个指针v出来，然后传递到push函数中，push函数中对于struct会先申请一段内存，同时把指针v对应的内容拷贝过去，最后，将指针v加入到cache中。这个做法会导致两个问题，第一个，将指针加入到cache这件事自身没有意义，因为每次都是new出来的指针，getObjCache始终会失效；第二个，removeObjCache是针对拷贝出来struct，并没有对指针v，导致指针v一直没有被释放，导致内存泄露。这里有一种修复方式为，当传递struct时，取消cache，并且delete掉new出来的指针。
![Snipaste_2021-05-16_10-55-14](https://user-images.githubusercontent.com/28628663/118385074-73164900-b63e-11eb-83c3-dd698b7a7289.png)
![Snipaste_2021-05-16_10-55-35](https://user-images.githubusercontent.com/28628663/118385077-76a9d000-b63e-11eb-8443-96d6122e2440.png)
![Snipaste_2021-05-16_10-56-08](https://user-images.githubusercontent.com/28628663/118385080-77dafd00-b63e-11eb-92ca-0a627569ffb0.png)


