### PR TITLE
Adding LuaSet

### DIFF
--- a/Content/Lua/Test.lua
+++ b/Content/Lua/Test.lua
@@ -51,6 +51,7 @@ function testcase()
     TestMap = require 'TestMap'
     TestArray = require 'TestArray'
     TestActor = require 'TestActor'
+    TestSet = require "TestSet"
 
     -- slua can detect dead loop code
     -- if lua exec timeout ,slua will report an error and jump out function 
@@ -68,6 +69,7 @@ function update(dt)
     TestArray.update(tt)
     TestMap.update(tt)
     TestBp:update(tt)
+    TestSet.update(tt)
 
     -- test weak ptr is alive?
     if slua.isValid(weakptr) then

--- a/Content/Lua/TestSet.lua
+++ b/Content/Lua/TestSet.lua
@@ -1,0 +1,97 @@
+local M = {}
+local Test = import("SluaTestCase")
+local t = Test()
+local set = t:GetSet()
+
+function M:Run()
+    self:IntTest()
+    self:StringTest()
+    self:ObjectTest()
+    self:GetSetTest()
+end
+
+function M:IntTest()
+    local x = slua.Set(EPropertyClass.Int)
+    local obj1 = 1
+    local obj2 = 2
+    self:Test(x, obj1, obj2)
+    print("[TestSet] Pass IntTest")
+end
+
+function M:StringTest()
+    local x = slua.Set(EPropertyClass.Str)
+    local obj1 = "string1"
+    local obj2 = "string2"
+    self:Test(x, obj1, obj2)
+    print("[TestSet] Pass StringTest")
+end
+
+function M:ObjectTest()
+    local UUserWidget = import("UserWidget")
+    local UIPath1 = "/Game/LuaPanel.LuaPanel"
+    local UIPath2 = "/Game/Panel.Panel"
+    local x = slua.Set(EPropertyClass.Object, UUserWidget)
+    local obj1 = slua.loadUI(UIPath1)
+    local obj2 = slua.loadUI(UIPath2)
+    self:Test(x, obj1, obj2)
+    print("[TestSet] Pass ObjectTest")
+end
+
+function M:Test(x, obj1, obj2)
+    assert(x:Num() == 0)
+
+    x:Add(obj1)
+    assert(x:Num() == 1)
+
+    local a, b = x:Get(obj1)
+    assert(a == obj1)
+    assert(b == true)
+
+    x:Add(obj1)
+    assert(x:Num() == 1)
+
+    a, b = x:Get(obj1)
+    assert(a == obj1)
+    assert(b == true)
+
+    x:Add(obj2)
+    assert(x:Num() == 2)
+
+    a, b = x:Get(obj2)
+    assert(a == obj2)
+    assert(b == true)
+
+    x:Remove(obj1)
+    assert(x:Num() == 1)
+
+    a, b = x:Get(obj1)
+    assert(a == nil)
+    assert(b == false)
+
+    x:Clear()
+    assert(x:Num() == 0)
+end
+
+function M:GetSetTest()
+    for i, v in pairs(set) do
+        local a, b = set:Get(v)
+        print("[SetTest] Item :", i, a, b)
+        assert(a == v)
+        assert(b == true)
+    end
+
+    set:Clear()
+    self:Test(set, 65535, 2147483647)
+    print("[SetTest] pass GetSetTest")
+end
+
+function M.update()
+    assert(set:Num() == 2)
+    assert(set:Get(65535) == 65535, true)
+end
+
+M:Run()
+set:Add(65535)
+set:Add(2147483647)
+
+return M

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaSet.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaSet.cpp
@@ -1,0 +1,341 @@
+#include "LuaSet.h"
+#include "LuaObject.h"
+#include "SluaLib.h"
+#include "LuaState.h"
+#include "LuaReference.h"
+
+#define GET_SET_CHECKER() \
+	const auto ElementChecker = LuaObject::getChecker(UD->InElementProperty);\
+	if (!ElementChecker) { \
+		const auto tn = UD->InElementProperty->GetClass()->GetName(); \
+		luaL_error(L, "Nonsupport type %s", TCHAR_TO_UTF8(*tn)); \
+		return 0; \
+	}
+
+namespace NS_SLUA
+{
+
+	DefTypeName(LuaSet::Enumerator);
+
+	LuaSet::LuaSet(FProperty* Property, FScriptSet* Buffer) :
+		Set(new FScriptSet),
+		InElementProperty(Property),
+		SetProperty(nullptr),
+		PropertyObject(nullptr),
+		Helper(FScriptSetHelper::CreateHelperFormElementProperty(InElementProperty, Set)),
+		ShouldFree(true)
+	{
+		clone(Set, Property, Buffer);
+	}
+
+	LuaSet::LuaSet(FSetProperty* Property, UObject* Object) :
+		Set(Property->ContainerPtrToValuePtr<FScriptSet>(Object)),
+		InElementProperty(Property->ElementProp),
+		SetProperty(Property),
+		PropertyObject(Object),
+		Helper(Property, Set),
+		ShouldFree(false)
+	{
+	}
+
+	LuaSet::~LuaSet()
+	{
+		if (ShouldFree)
+		{
+			clear();
+			ensure(Set);
+			SafeDelete(Set);
+		}
+		InElementProperty = nullptr;
+		SetProperty = nullptr;
+		PropertyObject = nullptr;
+	}
+
+	void LuaSet::reg(lua_State* L)
+	{
+		SluaUtil::reg(L, "Set", __ctor);
+	}
+
+	void LuaSet::clone(FScriptSet* DstSet, FProperty* InElementProperty, const FScriptSet* SrcSet)
+	{
+		if (!SrcSet || SrcSet->Num() == 0)
+			return;
+
+		FScriptSetHelper SrcHelper = FScriptSetHelper::CreateHelperFormElementProperty(InElementProperty, SrcSet);
+		FScriptSetHelper DstHelper = FScriptSetHelper::CreateHelperFormElementProperty(InElementProperty, DstSet);
+		DstHelper.EmptyElements(SrcHelper.Num());
+
+		for (auto n = 0; n < SrcHelper.GetMaxIndex(); n++)
+		{
+			if (SrcHelper.IsValidIndex(n))
+			{
+				const auto ElementPtr = SrcHelper.GetElementPtr(n);
+				DstHelper.AddElement(ElementPtr);
+			}
+		}
+	}
+
+	int LuaSet::push(lua_State* L, FProperty* Property, FScriptSet* Set)
+	{
+		LuaSet* NewSet = new LuaSet(Property, Set);
+		return LuaObject::pushType(L, NewSet, "LuaSet", setupMT, gc);
+	}
+
+	int LuaSet::push(lua_State* L, FSetProperty* prop, UObject* obj)
+	{
+		const auto ScriptSet = prop->ContainerPtrToValuePtr<FScriptSet>(obj);
+		if (LuaObject::getObjCache(L, ScriptSet, "LuaSet"))
+			return 1;
+
+		LuaSet* luaSet = new LuaSet(prop, obj);
+		const int r = LuaObject::pushType(L, luaSet, "LuaSet", setupMT, gc);
+		if (r)
+			LuaObject::cacheObj(L, luaSet->Set);
+		return 1;
+	}
+
+	int LuaSet::__ctor(lua_State* L)
+	{
+		FScriptSet Set = FScriptSet();
+
+		const auto ElementType = static_cast<EPropertyClass>(LuaObject::checkValue<int>(L, 1));
+		const auto UnClass = LuaObject::checkValueOpt<UClass*>(L, 2, nullptr);
+
+		if (ElementType == EPropertyClass::Object && !UnClass)
+		{
+			luaL_error(L, "The 2nd parameter should be UClass for the set of UObject");
+		}
+		
+		return push(L, PropertyProto::createProperty(PropertyProto(ElementType, UnClass)), &Set);
+	}
+
+	int LuaSet::Num(lua_State* L)
+	{
+		CheckUD(LuaSet, L, 1);
+		return LuaObject::push(L, UD->num());
+	}
+
+	int LuaSet::Get(lua_State* L)
+	{
+		CheckUD(LuaSet, L, 1);
+		GET_SET_CHECKER()
+		const FDefaultConstructedPropertyElement tempElement(UD->InElementProperty);
+		const auto ElementPtr = tempElement.GetObjAddress();
+		ElementChecker(L, UD->InElementProperty, static_cast<uint8*>(ElementPtr), 2);
+
+		const auto Index = UD->Helper.FindElementIndexFromHash(ElementPtr);
+		if (Index != INDEX_NONE)
+		{
+			LuaObject::push(L, UD->InElementProperty, UD->Helper.GetElementPtr(Index));
+			LuaObject::push(L, true);
+		}
+		else
+		{
+			LuaObject::pushNil(L);
+			LuaObject::push(L, false);
+		}
+		return 2;
+	}
+
+	int LuaSet::Add(lua_State* L)
+	{
+		CheckUD(LuaSet, L, 1);
+		GET_SET_CHECKER();
+		const FDefaultConstructedPropertyElement tempElement(UD->InElementProperty);
+		const auto ElementPtr = tempElement.GetObjAddress();
+		ElementChecker(L, UD->InElementProperty, static_cast<uint8*>(ElementPtr), 2);
+		UD->Helper.AddElement(ElementPtr);
+		return 0;
+	}
+
+	int LuaSet::Remove(lua_State* L)
+	{
+		CheckUD(LuaSet, L, 1);
+		GET_SET_CHECKER();
+		const FDefaultConstructedPropertyElement tempElement(UD->InElementProperty);
+		const auto ElementPtr = tempElement.GetObjAddress();
+		ElementChecker(L, UD->InElementProperty, static_cast<uint8*>(ElementPtr), 2);
+		return LuaObject::push(L, UD->removeElement(ElementPtr));
+	}
+
+	int LuaSet::Clear(lua_State* L)
+	{
+		CheckUD(LuaSet, L, 1);
+		UD->clear();
+		return 0;
+	}
+
+	int LuaSet::Pairs(lua_State* L)
+	{
+		CheckUD(LuaSet, L, 1);
+		Enumerator* Iter = new Enumerator();
+		// Hold reference of LuaSet, avoiding GC
+		Iter->Holder = new LuaVar(L, 1);
+		Iter->Set = UD;
+		Iter->Index = 0;
+		Iter->Num = UD->Helper.Num();
+
+		lua_pushcfunction(L, LuaSet::Enumerable);
+		LuaObject::pushType(L, Iter, "LuaSet::Enumerator", nullptr, Enumerator::gc);
+		LuaObject::pushNil(L);
+		return 3;
+	}
+
+	int LuaSet::Enumerable(lua_State* L)
+	{
+		CheckUD(LuaSet::Enumerator, L, 1);
+		LuaSet* Set = UD->Set;
+		FScriptSetHelper& Helper = Set->Helper;
+
+		while (UD->Num > 0)
+		{
+			if (Helper.IsValidIndex(UD->Index))
+			{
+				const auto ElementPtr = Helper.GetElementPtr(UD->Index);
+				LuaObject::push(L, UD->Index);
+				LuaObject::push(L, Set->InElementProperty, ElementPtr);
+				UD->Index += 1;
+				UD->Num -= 1;
+				return 2;
+			}
+			UD->Index += 1;
+		}
+		return 0;
+	}
+
+	void LuaSet::AddReferencedObjects(FReferenceCollector& Collector)
+	{
+		if (InElementProperty)
+			InElementProperty->AddReferencedObjects(Collector);
+		if (SetProperty)
+			SetProperty->AddReferencedObjects(Collector);
+		if (PropertyObject)
+			Collector.AddReferencedObject(PropertyObject);
+		
+		if ((!ShouldFree && !PropertyObject) || num() <= 0)
+			return;
+		
+		bool Rehash = false;
+		for (int Index = Helper.GetMaxIndex() - 1; Index>= 0; Index--)
+		{
+			if (Helper.IsValidIndex(Index))
+			{
+				const auto ElementPtr = Helper.GetElementPtr(Index);
+				const bool ElementChanged = LuaReference::addRefByProperty(Collector, InElementProperty, ElementPtr, false);
+				if (ElementChanged)
+				{
+					removeAt(Index);
+					Rehash = true;
+				}
+			}
+		}
+		if (Rehash) Helper.Rehash();
+	}
+
+	int LuaSet::num() const
+	{
+		return Helper.Num();
+	}
+
+	void LuaSet::clear()
+	{
+		if (!InElementProperty)
+			return;
+		emptyElements();
+	}
+
+	FScriptSet* LuaSet::get() const
+	{
+		return Set;
+	}
+
+	// Rewrite FScriptSetHelper::EmptyElements by adding ShouldFree judgment. If it's true, cal the original one.
+	void LuaSet::emptyElements(int32 Slack)
+	{
+		if (ShouldFree) 
+		{
+			Helper.EmptyElements();
+		}
+		else 
+		{
+			checkSlow(Slack >= 0);
+			const int32 OldNum = num();
+			if (OldNum || Slack) 
+			{
+				Set->Empty(Slack, Helper.SetLayout);
+			}
+		}
+	}
+
+	// Modify FScriptSetHelper::RemoveAt by adding ShouldFree judgment. If it's true, call the original one.
+	void LuaSet::removeAt(int32 Index, int32 Count)
+	{
+		if (ShouldFree) {
+			Helper.RemoveAt(Index);
+		}
+		else {
+			check(Helper.IsValidIndex(Index));
+			for (; Count; ++Index) {
+				if (Helper.IsValidIndex(Index)) {
+					Set->RemoveAt(Index, Helper.SetLayout);
+					--Count;
+				}
+			}
+		}
+	}
+
+	// Modify FScriptSetHelper::RemoveAt for the use of our custom removeAt.
+	bool LuaSet::removeElement(const void* ElementToRemove)
+	{
+		FProperty* LocalElementPropForCapture = InElementProperty;
+		const auto FoundIndex = Set->FindIndex(
+			ElementToRemove,
+			Helper.SetLayout,
+			[LocalElementPropForCapture](const void* Element) { return LocalElementPropForCapture->GetValueTypeHash(Element); },
+			[LocalElementPropForCapture](const void* A, const void* B) { return LocalElementPropForCapture->Identical(A, B); }
+		);
+		if (FoundIndex != INDEX_NONE)
+		{
+			removeAt(FoundIndex);
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	int LuaSet::setupMT(lua_State* L)
+	{
+		LuaObject::setupMTSelfSearch(L);
+
+		RegMetaMethod(L, Num);
+		RegMetaMethod(L, Get);
+		RegMetaMethod(L, Add);
+		RegMetaMethod(L, Remove);
+		RegMetaMethod(L, Clear);
+		RegMetaMethod(L, Pairs);
+		
+		RegMetaMethodByName(L, "__pairs", Pairs);
+		return 0;
+	}
+
+	int LuaSet::gc(lua_State* L)
+	{
+		CheckUD(LuaSet, L, 1);
+		LuaObject::deleteFGCObject(L, UD);
+		return 0;
+	}
+
+	int LuaSet::Enumerator::gc(lua_State* L)
+	{
+		CheckUD(LuaSet::Enumerator, L, 1);
+		delete UD;
+		return 0;
+	}
+
+	LuaSet::Enumerator::~Enumerator()
+	{
+		SafeDelete(Holder);
+	}
+}

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
@@ -26,6 +26,7 @@
 #include "LuaWrapper.h"
 #include "LuaArray.h"
 #include "LuaMap.h"
+#include "LuaSet.h"
 #include "LuaSocketWrap.h"
 #include "LuaMemoryProfile.h"
 #include "HAL/RunnableThread.h"
@@ -361,6 +362,7 @@ namespace NS_SLUA {
         LuaClass::reg(L);
         LuaArray::reg(L);
         LuaMap::reg(L);
+        LuaSet::reg(L);
 #ifdef ENABLE_PROFILER
 		LuaProfiler::init(this);
 #endif

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaCppBinding.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaCppBinding.h
@@ -96,6 +96,11 @@ namespace NS_SLUA {
 		}
 
 		template <typename T>
+		static typename std::enable_if<TIsTSet<T>::Value, T>::type readArg(lua_State * L, int p) {
+            return LuaObject::checkTSet<T>(L, p);
+		}
+
+		template <typename T>
 		static typename std::enable_if<std::is_enum<T>::value, T>::type readArg(lua_State * L, int p) {
 			return LuaObject::checkEnumValue<T>(L, p);
 		}
@@ -129,6 +134,13 @@ namespace NS_SLUA {
 			if (!lua_isuserdata(L, p))
 				return T();
 			return LuaObject::checkTMap<T>(L, p);
+		}
+
+		template <typename T>
+		static typename std::enable_if<TIsTSet<T>::Value, T>::type readArg(lua_State * L, int p) {
+            if (!lua_isuserdata(L, p))
+                return T();
+            return LuaObject::checkTSet<T>(L, p);
 		}
 
 		template <typename T>

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaObject.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaObject.h
@@ -22,6 +22,7 @@
 #include "SluaUtil.h"
 #include "LuaArray.h"
 #include "LuaMap.h"
+#include "LuaSet.h"
 #include "Runtime/Launch/Resources/Version.h"
 
 #ifndef SLUA_CPPINST
@@ -130,6 +131,7 @@ namespace NS_SLUA {
 
     DefTypeName(LuaArray);
     DefTypeName(LuaMap);
+    DefTypeName(LuaSet);
 
     template<typename T>
     struct LuaOwnedPtr {
@@ -490,6 +492,13 @@ namespace NS_SLUA {
 			return UD->asTMap<KeyType, ValueType>(L);
 		}
 
+    	// check value if it's a TSet
+    	template<class T>
+    	static T checkTSet(lua_State* L, int p) {
+			CheckUD(LuaSet, L, p);
+			return UD->asTSet<typename T::ElementType>(L);
+        }
+
         template<typename T>
         static void* void_cast( const T* v ) {
             return reinterpret_cast<void *>(const_cast< T* >(v));
@@ -757,6 +766,11 @@ namespace NS_SLUA {
 		static int push(lua_State* L, const TMap<K,V>& v) {
 			return LuaMap::push(L, v);
 		}
+
+    	template<typename T>
+    	static int push(lua_State* L, const TSet<T>& v) {
+			return LuaSet::push(L, v);
+        }
 
 		// static int push(lua_State* L, FScriptArray* array);
         

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaSet.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaSet.h
@@ -1,0 +1,105 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "lua/lua.hpp"
+#include "UObject/UnrealType.h"
+#include "UObject/GCObject.h"
+#include "PropertyUtil.h"
+#include "Runtime/Launch/Resources/Version.h"
+
+namespace NS_SLUA {
+
+	// Traits class which determines whether or not a type is a TSet.
+	template <typename T> struct TIsTSet { enum { Value = false }; };
+
+	template <typename InElementType, typename KeyFuncs, typename Allocator>
+	struct TIsTSet<               TSet<InElementType, KeyFuncs, Allocator>> { enum { Value = true }; };
+
+	template <typename InElementType, typename KeyFuncs, typename Allocator>
+	struct TIsTSet<const          TSet<InElementType, KeyFuncs, Allocator>> { enum { Value = true }; };
+
+	template <typename InElementType, typename KeyFuncs, typename Allocator>
+	struct TIsTSet<      volatile TSet<InElementType, KeyFuncs, Allocator>> { enum { Value = true }; };
+
+	template <typename InElementType, typename KeyFuncs, typename Allocator>
+	struct TIsTSet<const volatile TSet<InElementType, KeyFuncs, Allocator>> { enum { Value = true }; };
+
+	class SLUA_UNREAL_API LuaSet : public FGCObject {
+
+	public:
+		LuaSet(FProperty* Property, FScriptSet* Buffer);
+		LuaSet(FSetProperty* Property, UObject* Object);
+		~LuaSet();
+		
+		static void reg(lua_State* L);
+		static void clone(FScriptSet* DstSet, FProperty* Property, const FScriptSet* SrcSet);
+		static int push(lua_State* L, FProperty* Property, FScriptSet* Set);
+		static int push(lua_State* L, FSetProperty* prop, UObject* obj); // for the use of LuaObject::push
+
+		template<typename T>
+		static int push(lua_State* L, const TSet<T>& V)
+		{
+			FProperty* Property = PropertyProto::createProperty(PropertyProto::get<T>());
+			const FScriptSet* Set = reinterpret_cast<const FScriptSet*>(&V);
+			return push(L, Property, const_cast<FScriptSet*>(Set));
+		}
+
+		// Otherwise the LuaSet is an abstract class and can't be created.
+		virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
+
+#if (ENGINE_MINOR_VERSION>=20) && (ENGINE_MAJOR_VERSION>=4)
+		virtual FString GetReferencerName() const override
+		{
+			return "LuaSet";
+		}
+#endif
+
+		FScriptSet* get() const;
+
+		template<typename T>
+		const TSet<T>& asTSet(lua_State* L) const
+		{
+			if (sizeof(T) != InElementProperty->ElementSize)
+				luaL_error(L, "Cast to TSet error, element size doesn't match (%d, %d)", sizeof(T), InElementProperty->ElementSize);
+			return *(reinterpret_cast<const TSet<T>*>(Set));
+		}
+		
+	protected:
+		static int __ctor(lua_State* L);
+		static int Num(lua_State* L);
+		static int Get(lua_State* L);
+		static int Add(lua_State* L);
+		static int Remove(lua_State* L);
+		static int Clear(lua_State* L);
+		static int Pairs(lua_State* L);
+		static int Enumerable(lua_State* L);
+
+	private:
+		FScriptSet* Set;
+		FProperty* InElementProperty;
+		FSetProperty* SetProperty;
+		UObject* PropertyObject;
+		FScriptSetHelper Helper;
+
+		bool ShouldFree;
+
+		struct Enumerator
+		{
+			LuaSet* Set = nullptr;
+			class LuaVar* Holder = nullptr;
+			int32 Index = 0;
+			int32 Num = 0;
+			
+			static int gc(lua_State* L);
+			~Enumerator();
+		};
+
+		static int setupMT(lua_State* L);
+		static int gc(lua_State* L);
+
+		int32 num() const;
+		void clear();
+		void emptyElements(int32 Slack = 0);
+		void removeAt(int32 Index, int32 Count = 1);
+		bool removeElement(const void* ElementToRemove);
+	};
+}

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/SluaUtil.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/SluaUtil.h
@@ -278,7 +278,17 @@ namespace NS_SLUA {
 		}
 	};
 
-	
+	template<typename T>
+	struct TypeName<TSet<T>, false> {
+		static SimpleString value()
+		{
+			SimpleString str;
+			str.append("TSet<");
+			str.append(TypeName<T>::value());
+			str.append(">");
+			return str;
+		}
+	};	
 
 	template<class R, class ...ARGS>
 	struct MakeGeneircTypeName {

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/slua.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/slua.h
@@ -20,6 +20,7 @@
 #include "LuaVar.h"
 #include "LuaArray.h"
 #include "LuaMap.h"
+#include "LuaSet.h"
 #include "LuaBase.h"
 #include "LuaActor.h"
 #include "LuaDelegate.h"

--- a/Source/democpp/SluaTestCase.cpp
+++ b/Source/democpp/SluaTestCase.cpp
@@ -384,6 +384,11 @@ TMap<int, FString> USluaTestCase::GetMap() {
 	return FruitMap;
 }
 
+TSet<int> USluaTestCase::GetSet() {
+    TSet<int> Set = { 0,1,2,3,1,2,3,5,7,9 };
+    return Set;
+}
+
 TArray<FString> USluaTestCase::GetArrayStr() {
     TArray<FString> array={"hello","world","nihao"};
     return array;

--- a/Source/democpp/SluaTestCase.h
+++ b/Source/democpp/SluaTestCase.h
@@ -108,6 +108,9 @@ public:
     TMap<int, FString> GetMap(/*TMap<int, FString> _map*/);
 
     UFUNCTION(BlueprintCallable, Category="Lua|TestCase")
+    TSet<int> GetSet();
+
+    UFUNCTION(BlueprintCallable, Category="Lua|TestCase")
     TArray<FString> GetArrayStr();
 
     UFUNCTION(BlueprintCallable, Category="Lua|TestCase")


### PR DESCRIPTION
1. 在Slua中增加LuaSet类，通过slua.Set调用，实现Num, Get, Add, Remove, Clear, Pairs接口

2. Slua通过反射获取蓝图中的Set时, 自动cast成LuaSet传递给lua

3. 支持TSetProperty，在LuaCppBinding和LuaVar中将TSet转换为LuaSet