### PR TITLE
fix(pc):remove listeners to avoid crash on pc when app exit

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
@@ -591,7 +591,9 @@ namespace NS_SLUA {
 	}
 #if (ENGINE_MINOR_VERSION>=23) && (ENGINE_MAJOR_VERSION>=4)
 	void LuaState::OnUObjectArrayShutdown() {
-		// nothing todo, we don't add any listener to FUObjectDeleteListener
+		// remove listeners to avoid crash on pc when app exit
+		GUObjectArray.RemoveUObjectCreateListener(this);
+		GUObjectArray.RemoveUObjectDeleteListener(this);
 	}
 #endif
 


### PR DESCRIPTION
there is a crash on PC when quit game, stack info like this:
```
Fatal error: [File:D:/Build/++UE4/Sync/Engine/Source/Runtime/CoreUObject/Private/UObject/UObjectArray.cpp] [Line: 414] 

All UObject delete listeners should be unregistered when shutting down the UObject array
```
already tested this pr could fix the crash.