### PR TITLE
增加网络值复制变量监听功能+UE5.2编译告警消除+修复若干bug

### DIFF
--- a/Content/Lua/LuaGameState.lua
+++ b/Content/Lua/LuaGameState.lua
@@ -47,6 +47,12 @@ function LuaGameState:ctor(selfType)
     self.Name = "LuaGameStateTestName"
 end
 
+function LuaGameState:_PostConstruct()
+    self:AddLuaNetListener("Position", function (Value)
+        print("LuaGameState On Position Assign:", Value.X, Value.Y, Value.Z)
+    end)
+end
+
 function LuaGameState:TestServerRPC(ArgInt, ArgStr, ArgBool)
     print("LuaGameState:TestServerRPC", ArgInt, ArgStr, ArgBool)
 end
@@ -76,7 +82,7 @@ function LuaGameState:ReceiveBeginPlay()
     self.bCanEverTick = true
     -- set bCanBeDamaged property in parent
     self.bCanBeDamaged = false
-    print("actor:ReceiveBeginPlay")
+    print("LuaGameState:ReceiveBeginPlay")
 
     local KismetSystemLibrary = import("KismetSystemLibrary")
     if KismetSystemLibrary.IsDedicatedServer(self) then

--- a/Plugins/slua_unreal/External/lua/lvm.cpp
+++ b/Plugins/slua_unreal/External/lua/lvm.cpp
@@ -160,6 +160,7 @@ static int forlimit (const TValue *obj, lua_Integer *p, lua_Integer step,
 void luaV_finishget (lua_State *L, const TValue *t, TValue *key, StkId val,
                       const TValue *slot) {
   int loop;  /* counter to avoid infinite loops */
+  const TValue *self = t;
   const TValue *tm;  /* metamethod */
   for (loop = 0; loop < MAXTAGLOOP; loop++) {
     if (slot == NULL) {  /* 't' is not a table? */
@@ -179,7 +180,7 @@ void luaV_finishget (lua_State *L, const TValue *t, TValue *key, StkId val,
       /* else will try the metamethod */
     }
     if (ttisfunction(tm)) {  /* is metamethod a function? */
-      luaT_callTM(L, tm, t, key, val, 1);  /* call it */
+      luaT_callTM(L, tm, self, key, val, 1);  /* call it */
       return;
     }
     t = tm;  /* else try to access 'tm[key]' */
@@ -203,6 +204,7 @@ void luaV_finishget (lua_State *L, const TValue *t, TValue *key, StkId val,
 void luaV_finishset (lua_State *L, const TValue *t, TValue *key,
                      StkId val, const TValue *slot) {
   int loop;  /* counter to avoid infinite loops */
+  const TValue *self = t;
   for (loop = 0; loop < MAXTAGLOOP; loop++) {
     const TValue *tm;  /* '__newindex' metamethod */
     if (slot != NULL) {  /* is 't' a table? */
@@ -226,7 +228,7 @@ void luaV_finishset (lua_State *L, const TValue *t, TValue *key,
     }
     /* try the metamethod */
     if (ttisfunction(tm)) {
-      luaT_callTM(L, tm, t, key, val, 0);
+      luaT_callTM(L, tm, self, key, val, 0);
       return;
     }
     t = tm;  /* else repeat assignment over 'tm' */

--- a/Plugins/slua_unreal/Source/slua_profile/Private/slua_profile_inspector.cpp
+++ b/Plugins/slua_unreal/Source/slua_profile/Private/slua_profile_inspector.cpp
@@ -1578,23 +1578,17 @@ void SProfilerWidget::DrawStdLine(const FGeometry& AllottedGeometry, FSlateWindo
                      1.0f
                     );
 
-//    FSlateColorBrush stBrushWhite_1 = FSlateColorBrush(FColorList::White);
-//    FSlateDrawElement::MakeBox(
-//                    OutDrawElements,
-//                    LayerId,
-//                    AllottedGeometry.ToPaintGeometry(FVector2D(0, positionY - 10), FVector2D(80, 15)),
-//                    &stBrushWhite_1,
-//                    ESlateDrawEffect::None,
-//                    FLinearColor::Black
-//                    );
-
     FSlateFontInfo FontInfo = FCoreStyle::Get().GetFontStyle("NormalFont");
     FontInfo.Size = 10.0f;
 
     FSlateDrawElement::MakeText(
                     OutDrawElements,
                     LayerId,
+#if (ENGINE_MINOR_VERSION>=2) && (ENGINE_MAJOR_VERSION==5)
+                    AllottedGeometry.ToPaintGeometry(AllottedGeometry.Size, FSlateLayoutTransform(1.0f, TransformPoint(1.0f, FVector2D(0, positionY - 10)))),
+#else
                     AllottedGeometry.ToPaintGeometry(FVector2D(0, positionY - 10), AllottedGeometry.Size),
+#endif
                     stdStr,
                     FontInfo,
                     ESlateDrawEffect::None,
@@ -1696,7 +1690,11 @@ int32 SProfilerWidget::OnPaint(const FPaintArgs& Args, const FGeometry& Allotted
         FSlateDrawElement::MakeText(
                                     OutDrawElements,
                                     LayerId,
+#if (ENGINE_MINOR_VERSION>=2) && (ENGINE_MAJOR_VERSION==5)
+                                    AllottedGeometry.ToPaintGeometry(AllottedGeometry.Size, FSlateLayoutTransform(1.0f, TransformPoint(1.0f, FVector2D(0, 95.0f)))),
+#else 
                                     AllottedGeometry.ToPaintGeometry(FVector2D(0, 95.0f), AllottedGeometry.Size),
+#endif
                                     m_stdMemStr[0] + TEXT(" —"),
                                     FontInfo,
                                     ESlateDrawEffect::None,
@@ -1706,7 +1704,11 @@ int32 SProfilerWidget::OnPaint(const FPaintArgs& Args, const FGeometry& Allotted
         FSlateDrawElement::MakeText(
                                     OutDrawElements,
                                     LayerId,
+#if (ENGINE_MINOR_VERSION>=2) && (ENGINE_MAJOR_VERSION==5)
+                                    AllottedGeometry.ToPaintGeometry(AllottedGeometry.Size, FSlateLayoutTransform(1.0f, TransformPoint(1.0f, FVector2D(0, 0)))),
+#else 
                                     AllottedGeometry.ToPaintGeometry(FVector2D(0, 0), AllottedGeometry.Size),
+#endif
                                     m_stdMemStr[1],
                                     FontInfo,
                                     ESlateDrawEffect::None,
@@ -1739,7 +1741,11 @@ int32 SProfilerWidget::OnPaint(const FPaintArgs& Args, const FGeometry& Allotted
             FSlateDrawElement::MakeBox(
                                        OutDrawElements,
                                        LayerId,
-                                       AllottedGeometry.ToPaintGeometry(boxBeginPoint, FVector2D(length, cMaxViewHeight)),
+#if (ENGINE_MINOR_VERSION>=2) && (ENGINE_MAJOR_VERSION==5)
+                                        AllottedGeometry.ToPaintGeometry(FVector2D(length, cMaxViewHeight), FSlateLayoutTransform(1.0f, TransformPoint(1.0f, boxBeginPoint))),
+#else 
+                                        AllottedGeometry.ToPaintGeometry(boxBeginPoint, FVector2D(length, cMaxViewHeight)),
+#endif
                                        &stBrushWhite_1,
                                        ESlateDrawEffect::None,
                                        boxColor

--- a/Plugins/slua_unreal/Source/slua_profile/slua_profile.Build.cs
+++ b/Plugins/slua_unreal/Source/slua_profile/slua_profile.Build.cs
@@ -21,7 +21,11 @@ public class slua_profile : ModuleRules
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
         // enable exception
         bEnableExceptions = true;
+#if UE_5_2_OR_LATER
+        IWYUSupport = IWYUSupport.None;
+#else
         bEnforceIWYU = false;
+#endif
         bEnableUndefinedIdentifierWarnings = false;
 
         PrivateDependencyModuleNames.AddRange(new string[] { "slua_unreal" });

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaFunctionAccelerator.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaFunctionAccelerator.cpp
@@ -199,7 +199,7 @@ namespace NS_SLUA
 #endif
         );
 
-        checkSlow(newStack.Locals || Function->ParmsSize == 0);
+        checkSlow(newStack.Locals || func->ParmsSize == 0);
         FOutParmRec** lastOut = &newStack.OutParms;
         AutoDestructor autoDestructor(propertyList, params, func->NumParms);
 

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNetSerialization.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNetSerialization.cpp
@@ -434,12 +434,11 @@ bool FLuaNetSerialization::Read(FNetDeltaSerializeInfo& deltaParms, FLuaNetSeria
 
         if (SerializeVersion == 0)
         {
-            proxy->dirtyMark = changes;
+            proxy->dirtyMark |= changes;
         }
         else
         {
-            proxy->dirtyMark.Clear();
-            proxy->flatDirtyMark = changes;
+            proxy->flatDirtyMark |= changes;
         }
 
         if (luaTablePtr)
@@ -616,7 +615,9 @@ bool FLuaNetSerialization::Write(FNetDeltaSerializeInfo& deltaParms, FLuaNetSeri
 #endif
         if (SerializeVersion == 1)
         {
+#if !UE_SERVER
             if (!conditionMap[COND_ReplayOnly])
+#endif
             {
                 CompareProperties(obj, *proxy, replicationFrame);
             }

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNetSerialization.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNetSerialization.cpp
@@ -616,7 +616,10 @@ bool FLuaNetSerialization::Write(FNetDeltaSerializeInfo& deltaParms, FLuaNetSeri
 #endif
         if (SerializeVersion == 1)
         {
-            CompareProperties(obj, *proxy, replicationFrame);
+            if (!conditionMap[COND_ReplayOnly])
+            {
+                CompareProperties(obj, *proxy, replicationFrame);
+            }
             UpdateChangeListMgr_V1(*proxy, replicationFrame);
         }
         else

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -1030,11 +1030,46 @@ namespace NS_SLUA {
         auto* objTable = ULuaOverrider::getObjectTable(obj, L);
         if (objTable && objTable->table.getState() == L->l_G->mainthread) {
             objTable->table.push(L); // push self
-            int type = lua_getfield(L, -1, name);
+            if (objTable->isInstance)
+            {
+                lua_pushstring(L, LuaOverrider::INSTANCE_CACHE_NAME);
+                if (lua_rawget(L, -2))
+                {
+                    lua_pushvalue(L, 2);
+                    if (lua_rawget(L, -2) != LUA_TNIL)
+                    {
+                        return 1;
+                    }
+                    lua_pop(L, 1);
+                }
+                lua_pop(L, 1);
+            }
+
+            lua_pushvalue(L, 2);
+            int type = lua_gettable(L, -2);
             if (type != LUA_TNIL) {
                 if (type == LUA_TFUNCTION) {
                     lua_pushcclosure(L, luaFuncClosure, 1);
-                    if (!objTable->isInstance)
+                    if (objTable->isInstance)
+                    {
+                        // cache instance function in self.__instance_cache
+                        lua_pushstring(L, LuaOverrider::INSTANCE_CACHE_NAME);
+                        if (lua_rawget(L, -3) == LUA_TNIL)
+                        {
+                            lua_pop(L, 1);
+
+                            lua_newtable(L);
+                            lua_pushstring(L, LuaOverrider::INSTANCE_CACHE_NAME);
+                            lua_pushvalue(L, -2);
+                            lua_rawset(L, -5);
+                        }
+                        lua_pushvalue(L, 2);
+                        lua_pushvalue(L, -3);
+                        lua_rawset(L, -3);
+                        
+                        lua_pop(L, 1); // pop __instance_cache
+                    }
+                    else
                     {
                         cacheFunction(L, nullptr);
                     }
@@ -1264,7 +1299,15 @@ namespace NS_SLUA {
         
         auto* cls = ls->uss;
         FProperty* up = LuaObject::findCacheProperty(L, cls, name);
-        if(!up) return 0;
+        if(!up) {
+            // index self metatable.
+            lua_getmetatable(L, 1);
+            lua_pushvalue(L, 2);
+            if (lua_gettable(L, -2)) {
+                return 1;
+            }
+            return 0;
+        }
 
         if (GSluaEnableReference)
         {
@@ -1369,9 +1412,10 @@ namespace NS_SLUA {
 
     int instanceIndexSelf(lua_State* L) {
         lua_getmetatable(L,1);
-        const char* name = lua_tostring(L, 2);
-        
-        lua_getfield(L,-1,name);
+
+        lua_pushvalue(L, 2); // push key name
+        lua_gettable(L, -2);
+
         lua_remove(L,-2); // remove mt of ud
         return 1;
     }

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
@@ -742,6 +742,7 @@ namespace NS_SLUA
         }
 
         auto actorComponent = Cast<UActorComponent>(obj);
+        auto luaInterface = Cast<ILuaOverriderInterface>(obj);
         if (actorComponent)
         {
             actorComponent->bWantsInitializeComponent = true;
@@ -754,7 +755,7 @@ namespace NS_SLUA
             ensure(tempClassHookLinker->cls == cls);
             auto overrider = tempClassHookLinker->overrider;
             auto currentLinker = tempClassHookLinker;
-            if (!actorComponent)
+            if (!actorComponent || !luaInterface)
             {
                 overrider->bindOverrideFuncs(obj, cls);
             }

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
@@ -478,6 +478,7 @@ namespace NS_SLUA
     const char* LuaOverrider::UOBJECT_NAME = "Object";
     const char* LuaOverrider::SUPER_NAME = "Super";
     const char* LuaOverrider::CACHE_NAME = "__cache";
+    const char* LuaOverrider::INSTANCE_CACHE_NAME = "__instance_cache";
     const uint8 LuaOverrider::Code[] = { (uint8)Ex_LuaOverride, EX_Return, EX_Nothing };
     const int32 LuaOverrider::CodeSize = sizeof(Code);
     FRWLock LuaOverrider::classHookMutex;

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
@@ -624,6 +624,9 @@ namespace NS_SLUA
             }
 
             LuaNet::onObjectDeleted(cls);
+
+            FRWScopeLock lock(classHookMutex, SLT_Write);
+            classConstructors.Remove(cls);
         }
     }
 

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
@@ -688,18 +688,23 @@ namespace NS_SLUA
         {
             FRWScopeLock lock(classHookMutex, SLT_Write);
             UClass::ClassConstructorType *classConstructorFuncPtr = nullptr;
+            TArray<UClass*, TMemStackAllocator<>> handleClasses;
             auto superCls = cls;
             while (classConstructorFuncPtr == nullptr && superCls)
             {
                 classConstructorFuncPtr = classConstructors.Find(superCls);
-                if (classConstructorFuncPtr && superCls != cls)
+                if (!classConstructorFuncPtr)
                 {
-                    classConstructors.Add(cls, *classConstructorFuncPtr);
+                    handleClasses.Add(superCls);
                 }
                 superCls = superCls->GetSuperClass();
             }
             check(classConstructorFuncPtr != nullptr);
             clsConstructor = *classConstructorFuncPtr;
+            for (auto iter = handleClasses.CreateConstIterator(); iter; ++iter)
+            {
+                classConstructors.Emplace(*iter, clsConstructor);
+            }
         }
         
         check(clsConstructor != CustomClassConstructor);

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
@@ -553,7 +553,10 @@ namespace NS_SLUA
         for (auto iter : classConstructors)
         {
             auto cls = iter.Key.Get();
-            cls->ClassConstructor = iter.Value;
+            if (cls)
+            {
+                cls->ClassConstructor = iter.Value;
+            }
         }
         classConstructors.Empty();
     }

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
@@ -788,6 +788,7 @@ namespace NS_SLUA {
     void LuaState::NotifyUObjectDeleted(const UObjectBase * Object, int32 Index)
     {
         classMap.cachePropMap.Remove((UStruct*)Object);
+        LuaObject::removeCache(L, Object, cacheEnumRef);
         LuaObject::removeCache(L, Object, cacheClassPropRef);
         LuaObject::removeCache(L, Object, cacheClassFuncRef);
         LuaFunctionAccelerator::remove((UFunction*)Object);

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
@@ -72,9 +72,9 @@ namespace NS_SLUA {
         const char* err = lua_tostring(L,1);
         luaL_traceback(L,L,err,1);
         err = lua_tostring(L,2);
-        lua_pop(L,1);
         auto ls = LuaState::get(L);
         ls->onError(err);
+        lua_pop(L,1);
         return 0;
     }
     

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaVar.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaVar.cpp
@@ -731,7 +731,7 @@ namespace NS_SLUA {
                     FOutParmRec* out = outParams;
                     while (out->Property != prop) {
                         out = out->NextOutParm;
-                        checkSlow(Out);
+                        checkSlow(out);
                     }
                     pushArgByParms(prop, out->PropAddr);
                     nArg++;

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaNet.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaNet.h
@@ -21,6 +21,8 @@ namespace NS_SLUA
     class SLUA_UNREAL_API LuaNet
     {
     public:
+        typedef TFunction<void ()> PrepareParamCallback;
+
         // Only support c++ native UClass
         static void addLuaRepilcateClass(const UClass* someBase);
         static bool isLuaReplicateObject(UObject* obj);
@@ -37,8 +39,12 @@ namespace NS_SLUA
         static void removeObjectTable(UObject* obj);
         static void onObjectDeleted(UClass* cls);
 
+        static void onPropModify(lua_State* L, FLuaNetSerializationProxy* proxy, ClassLuaReplicated::ReplicateIndexType index, PrepareParamCallback callback);
+
     protected:
         friend class LuaOverrider;
+        static const char* ADD_LISTENER_FUNC;
+        static const char* REMOVE_LISTENER_FUNC;
         
         void addClassRPC(lua_State* L, UClass* cls, const FString& luaFilePath);
         bool addClassRPCRecursive(lua_State* L, UClass* cls, const FString& luaFilePath, LuaVar& cppSuperModule);
@@ -51,6 +57,10 @@ namespace NS_SLUA
 
         static int __index(lua_State* L, UObject* obj, const char* keyName);
         static int __newindex(lua_State* L, UObject* obj, const char* keyName);
+
+        static int setupFunctions(lua_State* L);
+        static int addListener(lua_State* L);
+        static int removeListener(lua_State* L);
         
         typedef TMap<TWeakObjectPtr<UClass>, ClassLuaReplicated, FDefaultSetAllocator, TWeakObjectPtrMapKeyFuncs<TWeakObjectPtr<UClass>, ClassLuaReplicated>> ClassLuaReplicatedMap;
         static ClassLuaReplicatedMap classLuaReplicatedMap;

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaNetSerialization.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaNetSerialization.h
@@ -167,6 +167,7 @@ struct FLuaNetSerializationProxy : public FGCObject
     
     LuaBitArray flatDirtyMark;
     TMap<int32, LuaBitArray> arrayDirtyMark;
+    TMap<ClassLuaReplicated::ReplicateIndexType, TArray<NS_SLUA::LuaVar*>> propListeners;
     
     TWeakObjectPtr<UStruct> contentStruct;
 
@@ -187,7 +188,7 @@ struct FLuaNetSerializationProxy : public FGCObject
 #endif
 
     virtual void AddReferencedObjects( FReferenceCollector& Collector );
-    
+    ~FLuaNetSerializationProxy();
 };
 
 USTRUCT()

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaOverrider.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaOverrider.h
@@ -121,52 +121,10 @@ namespace NS_SLUA
         bool hookBpScript(UFunction* func, UClass* cls, FNativeFuncPtr hookFunc);
 
         static void CustomClassConstructor(const FObjectInitializer& ObjectInitializer);
-        
-        struct ClassHookLinker
-        {
-            ClassHookLinker* pre;
-            ClassHookLinker* next;
-            LuaOverrider* overrider;
-            UObject* obj;
-            UClass* cls;
-            UClass::ClassConstructorType clsConstructor;
 
-            ClassHookLinker()
-                : pre(this)
-                , next(this)
-                , overrider(nullptr)
-                , obj(nullptr)
-                , cls(nullptr)
-                , clsConstructor(nullptr)
-            {
-            }
-
-            ClassHookLinker(LuaOverrider* _overrider, UObject* _obj, UClass* _cls, ClassHookLinker* _pre)
-                : pre(_pre)
-                , next(_pre->next)
-                , overrider(_overrider)
-                , obj(_obj)
-                , cls(_cls)
-            {
-                _pre->next = this;
-                next->pre = this;
-
-                clsConstructor = cls->ClassConstructor;
-                while (clsConstructor == CustomClassConstructor && (_pre->obj == obj || _pre->cls == cls))
-                {
-                    clsConstructor = _pre->clsConstructor;
-                    _pre = _pre->pre;
-                }
-
-                if (clsConstructor != CustomClassConstructor)
-                {
-                    cls->ClassConstructor = CustomClassConstructor;
-                }
-                ensure(clsConstructor != CustomClassConstructor);
-            }
-        };
         static FRWLock classHookMutex;
-        static ClassHookLinker* currentHook;
+        static TMap<TWeakObjectPtr<UClass>, UClass::ClassConstructorType> classConstructors;
+        static TMap<UObject*, TArray<LuaOverrider*>> objectOverriders;
 
         static int __index(lua_State* L);
         static int classIndex(lua_State* L);

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaOverrider.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaOverrider.h
@@ -147,7 +147,9 @@ namespace NS_SLUA
                 , obj(_obj)
                 , cls(_cls)
             {
-                pre->next = this;
+                _pre->next = this;
+                next->pre = this;
+
                 clsConstructor = cls->ClassConstructor;
                 while (clsConstructor == CustomClassConstructor && (_pre->obj == obj || _pre->cls == cls))
                 {

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaOverrider.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaOverrider.h
@@ -82,6 +82,7 @@ namespace NS_SLUA
         static const char* UOBJECT_NAME;
         static const char* SUPER_NAME;
         static const char* CACHE_NAME;
+        static const char* INSTANCE_CACHE_NAME;
         
         LuaOverrider(LuaState* luaState);
         ~LuaOverrider();

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaOverrider.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaOverrider.h
@@ -115,7 +115,7 @@ namespace NS_SLUA
         void onEngineGC();
 
         bool bindOverrideFuncs(const UObjectBase* objBase, UClass* cls);
-        void setmetatable(const LuaVar& luaSelfTable, void* objPtr);
+        void setmetatable(const LuaVar& luaSelfTable, void* objPtr, bool bNetReplicated);
 
         bool hookBpScript(UFunction* func, UClass* cls, FNativeFuncPtr hookFunc);
 

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/SluaUtil.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/SluaUtil.h
@@ -169,11 +169,7 @@ namespace NS_SLUA {
 
         FORCEINLINE bool operator == (const SimpleString& Other) const
         {
-#if defined(_WIN32)
-            return _stricmp(data.GetData(), Other.data.GetData()) == 0;
-#else
-            return strcasecmp(data.GetData(), Other.data.GetData()) == 0;
-#endif
+            return FPlatformString::Stricmp(data.GetData(), Other.data.GetData()) == 0;
         }
     };
 

--- a/Plugins/slua_unreal/Source/slua_unreal/slua_unreal.Build.cs
+++ b/Plugins/slua_unreal/Source/slua_unreal/slua_unreal.Build.cs
@@ -21,7 +21,11 @@ public class slua_unreal : ModuleRules
         PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
         // enable exception
         bEnableExceptions = true;
+#if UE_5_2_OR_LATER
+        IWYUSupport = IWYUSupport.None;
+#else
         bEnforceIWYU = false;
+#endif
         bEnableUndefinedIdentifierWarnings = false;
 
         var externalSource = Path.Combine(ModuleDirectory, "../../External");

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ return Class(nil, nil, LuaActor)
 
 ## 性能
 
-slua-unreal提供3中技术绑定lua接口，包括：
+slua-unreal提供3种技术绑定lua接口，包括：
 
 1）蓝图反射方法
 

--- a/Source/democpp/democpp.Build.cs
+++ b/Source/democpp/democpp.Build.cs
@@ -8,9 +8,9 @@ public class democpp : ModuleRules
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 	
-		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "Http" });
+		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "HTTP" });
 
-		PrivateDependencyModuleNames.AddRange(new string[] { "slua_unreal", "slua_profile", "Slate", "SlateCore", "UMG", "Http" });
+		PrivateDependencyModuleNames.AddRange(new string[] { "slua_unreal", "slua_profile", "Slate", "SlateCore", "UMG", "HTTP" });
 
         PrivateIncludePathModuleNames.AddRange(new string[] { "slua_unreal" });
         PublicIncludePathModuleNames.AddRange(new string[] { "slua_unreal","slua_profile" });


### PR DESCRIPTION
1、增加网络值复制变量监听功能，API：AddLuaNetListener/RemoveLuaNetListener
2、修复UEnum类型值可能访问为nil的bug，原因是FName是忽略大小写的，而UEnum import时生成table根据它的FName生成对应键值
3、修复网络值复制Replay录制回放bug
4、简化自定义构造函数的Hook流程
5、消除UE 5.2版本编译告警