### PR TITLE
初始化未初始化的变量，不然启动编辑器会有报错

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Public/ProfileDataDefine.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/ProfileDataDefine.h
@@ -98,10 +98,10 @@ struct SLUA_UNREAL_API FunctionProfileCallInfo
         FString functionName;
 
     UPROPERTY()
-        int64 begTime;
+        int64 begTime = 0;
 
     UPROPERTY()
-        bool bIsCoroutineBegin;
+        bool bIsCoroutineBegin = false;
 
     TSharedPtr<FunctionProfileNode> ProfileNode;
 };
@@ -144,4 +144,16 @@ struct SLUA_UNREAL_API FunctionProfileInfo
         bool isDuplicated = false;
     UPROPERTY()
         TArray<int> mergeIdxArray;
+
+    FunctionProfileInfo():
+        begTime(0),
+        endTime(0),
+        costTime(0),
+        mergedCostTime(0),
+        globalIdx(0),
+        layerIdx(0),
+        mergedNum(0),
+        beMerged(false)
+    {
+    }
 };


### PR DESCRIPTION
并不影响实际功能，只是在编辑器启动的时候会有红字报错，在5.2和5.3上发现，更早的版本没有确认