### PR TITLE
修复一个bug并且解开Property ReadOnly只读的限制

### DIFF
--- a/Content/Lua/TestCase.lua
+++ b/Content/Lua/TestCase.lua
@@ -120,3 +120,10 @@ print("info",info)
 
 map1 = t:GetMap()
 print("map1",map1)
+
+local SluaTestCase=import('SluaTestCase');
+local t=SluaTestCase()
+for k, v in pairs(t) do
+    print("SluaTestCase iter", k, v)
+end
+print("SluaTestCase weakptr:", t.weakptr) ---expect as uobject type not LuaArray.

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -1337,8 +1337,17 @@ namespace NS_SLUA {
             return 1;
         }
 
+        lua_pop(L, 1); // pop previous key to compatible with LuaObject::pushReferenceAndCache method
+
         FString key = up->GetName();
         lua_pushstring(L, TCHAR_TO_UTF8(*key));
+
+        if (int res = LuaObject::fastIndex(L, (uint8*)obj, obj->GetClass()))
+        {
+            lua_pushvalue(L, 2);
+            lua_pushvalue(L, -2);
+            return res + 1;
+        }
 
         return LuaObject::push(L, up, obj, nullptr) + 1;
     }
@@ -1484,8 +1493,17 @@ namespace NS_SLUA {
             return 1;
         }
 
+        lua_pop(L, 1); // pop previous key to compatible with LuaObject::pushReferenceAndCache method
+
         FString key = getPropertyFriendlyName(up);
         lua_pushstring(L, TCHAR_TO_UTF8(*key));
+
+        if (int res = LuaObject::fastIndex(L, ls->buf, ls->uss))
+        {
+            lua_pushvalue(L, 2);
+            lua_pushvalue(L, -2);
+            return res + 1;
+        }
 
         return LuaObject::push(L, up, ls->buf + up->GetOffset_ForInternal(), nullptr) + 1;
     }

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -1259,8 +1259,6 @@ namespace NS_SLUA {
             else
                 return false;
         }
-        if (up->GetPropertyFlags() & CPF_BlueprintReadOnly)
-            luaL_error(L, "Property %s is readonly", name);
 
         auto checker = LuaObject::getChecker(up);
         if (!checker) luaL_error(L, "Property %s type is not support", name);
@@ -1415,8 +1413,6 @@ namespace NS_SLUA {
         auto* cls = ls->uss;
         FProperty* up = LuaObject::findCacheProperty(L, cls, name);
         if (!up) luaL_error(L, "Can't find property named %s", name);
-        if (up->GetPropertyFlags() & CPF_BlueprintReadOnly)
-            luaL_error(L, "Property %s is readonly", name);
 
         auto checker = LuaObject::getChecker(up);
         if(!checker) luaL_error(L,"Property %s type is not support",name);


### PR DESCRIPTION
1、修复UObject遍历时，Struct/Array/Map/Set等类型成员变量会覆盖导上一个变量上的bug
2、接口ReadOnly Property在lua中不能赋值的限制