### PR TITLE
Fix shadow compiling error under MSVC 14.29.30133

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNet.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNet.cpp
@@ -136,8 +136,8 @@ namespace NS_SLUA
                         auto luaReplicatedTable = getLifetimeFunc.call();
                         if (luaReplicatedTable.isTable())
                         {
-                            auto classReplicatedPtr = classLuaReplicatedMap.Add(cls, new ClassLuaReplicated());
-                            auto& classReplicated = *classReplicatedPtr;
+                            auto classReplicatedPtr2 = classLuaReplicatedMap.Add(cls, new ClassLuaReplicated());
+                            auto& classReplicated = *classReplicatedPtr2;
                             classReplicated.ownerProperty = prop;
                     
                             auto &replicatedNameToIndexMap = classReplicated.replicatedNameToIndexMap;

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNet.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNet.cpp
@@ -136,8 +136,7 @@ namespace NS_SLUA
                         auto luaReplicatedTable = getLifetimeFunc.call();
                         if (luaReplicatedTable.isTable())
                         {
-                            auto classReplicatedPtr2 = classLuaReplicatedMap.Add(cls, new ClassLuaReplicated());
-                            auto& classReplicated = *classReplicatedPtr2;
+                            auto& classReplicated = *classLuaReplicatedMap.Add(cls, new ClassLuaReplicated());
                             classReplicated.ownerProperty = prop;
                     
                             auto &replicatedNameToIndexMap = classReplicated.replicatedNameToIndexMap;


### PR DESCRIPTION
Fix compiling error causing by shadowing.

```
Using Visual Studio 2019 14.29.30148 toolchain (E:\VS\VC\Tools\MSVC\14.29.30133) and Windows 10.0.22621.0 SDK (C:\Program Files (x86)\Windows Kits\10).

slua_unreal/Source/slua_unreal/Private/LuaNet.cpp(139): error C4456: declaration of 'classReplicatedPtr' hides previous local declaration
```