### PR TITLE
Add FMemMark for FMemStack Pop

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
@@ -74,6 +74,7 @@ void ULuaOverrider::luaOverrideFunc(UObject* Context, FFrame& Stack, RESULT_DECL
     bool bCallFromNative = false;
     bool bContextOp = false;
     
+    FMemMark MemMark(FMemStack::Get());
     TArray<FProperty*, TMemStackAllocator<>> propertyToDestructList;
 
     if (Stack.CurrentNativeFunction)
@@ -719,6 +720,7 @@ namespace NS_SLUA
         {
             FRWScopeLock lock(classHookMutex, SLT_Write);
             UClass::ClassConstructorType *classConstructorFuncPtr = nullptr;
+            FMemMark MemMark(FMemStack::Get());
             TArray<UClass*, TMemStackAllocator<>> handleClasses;
             auto superCls = cls;
             while (classConstructorFuncPtr == nullptr && superCls)


### PR DESCRIPTION
TArray的内存分配器使用了TMemStackAllocator，其内部使用的FMemStack需要和FMemMark配套使用，否则FMemStack只考虑Push内存，不考虑Pop。
TArray本身的析构函数只负责析构其元素所占用内存的有效值，不管理内存本身的释放。
FMemMark会在离开Scope后将FMemStack的内存结构恢复至初始状态。
也可以参考引擎其它使用TMemStackAllocator位置的代码。