### PR TITLE
cls nullptr check

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
@@ -935,7 +935,7 @@ namespace NS_SLUA
 #if WITH_EDITOR
     void clearSuperFuncCache(UClass* cls)
     {
-        if (!cls->IsValidLowLevel() || !IsValid(cls))
+        if (!cls || !cls->IsValidLowLevel() || !IsValid(cls))
         {
             return;
         }


### PR DESCRIPTION
检查cls空指针，不依赖IsValidLowLevel中的this == nullptr（非标准）
主要是有warning