### PR TITLE
主要是修复一些崩溃bug和一些特性支持、调整

### DIFF
--- a/Content/Lua/LuaGameState.lua
+++ b/Content/Lua/LuaGameState.lua
@@ -43,8 +43,8 @@ LuaGameState.MulticastRPC.TestMulticastRPC = {
     }
 }
 
-function LuaGameState:ctor(selfType)
-    print("LuaGameState ctor", selfType, assert(selfType == require("LuaGameState")))
+function LuaGameState:ctor()
+    print("LuaGameState ctor", assert(selfType == require("LuaGameState")))
     self.Name = "LuaGameStateTestName"
     self.TickCounter = 0
 end

--- a/Plugins/slua_unreal/Source/slua_profile/Private/slua_profile_inspector.cpp
+++ b/Plugins/slua_unreal/Source/slua_profile/Private/slua_profile_inspector.cpp
@@ -33,8 +33,8 @@
 #if WITH_EDITOR
 #include "EditorStyleSet.h"
 #endif
-#include "NotificationManager.h"
-#include "SNotificationList.h"
+#include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
 #include "Serialization/ArrayWriter.h"
 #include "Misc/FileHelper.h"
 #include "HAL/FileManager.h"

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaArray.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaArray.cpp
@@ -309,7 +309,9 @@ namespace NS_SLUA {
             prop = PropertyProto::createProperty(PropertyProto(type));
             break;
         }
-        
+        if (!prop) {
+            luaL_error(L, "Unsupported type[%d] of LuaArray!", type);
+        }
         auto array = FScriptArray();
         return push(L, prop, &array, true);
     }

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaDelegate.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaDelegate.cpp
@@ -104,7 +104,7 @@ int ULuaDelegate::removeLuaDelegate(NS_SLUA::lua_State* L, ULuaDelegate* obj)
     return 0;
 }
 
-int ULuaDelegate::removeLuaDelegateByHandle(slua::lua_State* L, int64 handle)
+int ULuaDelegate::removeLuaDelegateByHandle(NS_SLUA::lua_State* L, int64 handle)
 {
     auto objPtr = DelegateHandleToObjectMap.Find(handle);
     if (!objPtr)

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaDelegate.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaDelegate.cpp
@@ -321,7 +321,7 @@ namespace NS_SLUA {
         return 0;
     }
 
-    int LuaMultiDelegate::BroadCast(lua_State* L) {
+    int LuaMultiDelegate::Broadcast(lua_State* L) {
         CheckUD(LuaMultiDelegateWrap,L,1);
 
         auto callBroadcast = [UD, L](const FMulticastScriptDelegate* delegate)
@@ -378,7 +378,7 @@ namespace NS_SLUA {
         RegMetaMethod(L,Add);
         RegMetaMethod(L,Remove);
         RegMetaMethod(L,Clear);
-        RegMetaMethod(L,BroadCast);
+        RegMetaMethod(L,Broadcast);
         return 0;
     }
 

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaMemoryProfile.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaMemoryProfile.cpp
@@ -123,10 +123,10 @@ namespace NS_SLUA {
 
     void LuaMemoryProfile::onStart(LuaState* LS)
     {
-        auto *memoryRecord = TryGetMemoryRecord(LS);
-        auto *memoryIncrease = TryGetMemoryIncrease(LS);
-        memoryRecord->Empty();
-        memoryIncrease->Empty();
+        auto *memRecord = TryGetMemoryRecord(LS);
+        auto *memIncrease = TryGetMemoryIncrease(LS);
+        memRecord->Empty();
+        memIncrease->Empty();
     }
 
     void LuaMemoryProfile::stop(lua_State* L)

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNet.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNet.cpp
@@ -115,7 +115,7 @@ namespace NS_SLUA
         luaRPCTypeMap.Add(rpcType, netFlag);
     }
 
-    ClassLuaReplicated* LuaNet::addClassReplicatedProps(slua::lua_State* L, UObject* obj, const slua::LuaVar& luaModule)
+    ClassLuaReplicated* LuaNet::addClassReplicatedProps(NS_SLUA::lua_State* L, UObject* obj, const NS_SLUA::LuaVar& luaModule)
     {
 #if (ENGINE_MINOR_VERSION<25) && (ENGINE_MAJOR_VERSION==4)
         typedef NS_SLUA::EPropertyClass EPropertyClass;
@@ -348,8 +348,8 @@ namespace NS_SLUA
         }
     }
 
-    void LuaNet::initLuaReplicatedProps(slua::lua_State* L, UObject* obj, const ClassLuaReplicated& classReplicated,
-        const slua::LuaVar& luaTable)
+    void LuaNet::initLuaReplicatedProps(NS_SLUA::lua_State* L, UObject* obj, const ClassLuaReplicated& classReplicated,
+        const NS_SLUA::LuaVar& luaTable)
     {
         auto prop = classReplicated.ownerProperty.Get();
         if (!prop)

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNet.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNet.cpp
@@ -26,7 +26,7 @@ namespace NS_SLUA
     LuaNet::ClassLuaReplicatedMap LuaNet::classLuaReplicatedMap;
     LuaNet::LuaNetSerializationMap LuaNet::luaNetSerializationMap;
     LuaNet::ObjectToLuaNetAddressMap LuaNet::objectToLuaNetAddressMap;
-    TArray<const UClass*> LuaNet::luaReplicateClasses;
+    TArray<const UClass*, TAlignedHeapAllocator<16>> LuaNet::luaReplicateClasses;
     TSet<TWeakObjectPtr<UClass>> LuaNet::addedRPCClasses;
 #if WITH_EDITOR
     TSet<TWeakObjectPtr<UFunction>> LuaNet::luaRPCFuncs;

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNet.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNet.cpp
@@ -15,7 +15,9 @@
 #include "LuaOverrider.h"
 #include "LuaOverriderInterface.h"
 #include "LuaNetSerialization.h"
+#include "UObject/Package.h"
 #include "Engine/NetDriver.h"
+#include "Engine/GameInstance.h"
 
 namespace NS_SLUA
 {

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNetSerialization.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaNetSerialization.cpp
@@ -450,7 +450,7 @@ void FLuaNetSerialization::ReadItem(FNetDeltaSerializeInfo& deltaParms, NS_SLUA:
         auto &arrayPropInfo = classReplicated->flatArrayPropInfos[flatOffset];
         auto &flatReplicateProperties = arrayPropInfo.properties;
         auto innerPropNum = arrayPropInfo.innerPropertyNum;
-        auto innerProp = CastField<slua::FArrayProperty>(flatPropInfo.prop)->Inner;
+        auto innerProp = CastField<NS_SLUA::FArrayProperty>(flatPropInfo.prop)->Inner;
         auto arrayHelper = FScriptArrayHelper::CreateHelperFormInnerProperty(innerProp, data + flatOffset);
 
         int32 arrayNum = 0;
@@ -1077,7 +1077,7 @@ bool FLuaNetSerialization::IsSupportSharedSerialize(NS_SLUA::FProperty* prop)
 }
 
 
-void FLuaNetSerialization::CallOnRep(NS_SLUA::lua_State* L, const slua::LuaVar& luaTable, const FString& propName, NS_SLUA::FProperty* prop, uint8* oldData)
+void FLuaNetSerialization::CallOnRep(NS_SLUA::lua_State* L, const NS_SLUA::LuaVar& luaTable, const FString& propName, NS_SLUA::FProperty* prop, uint8* oldData)
 {
     QUICK_SCOPE_CYCLE_COUNTER(LuaNetDeltaSerialization_CallOnRep);
     const FString funcName = "OnRep_" + propName;

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -1846,7 +1846,7 @@ namespace NS_SLUA {
     int pushUWeakProperty(lua_State* L, FProperty* prop, uint8* parms, int i, NewObjectRecorder* objRecorder) {
         auto p = CastField<FWeakObjectProperty>(prop);
         ensure(p);
-        FWeakObjectPtr v = p->GetPropertyValue(parms);
+        const FWeakObjectPtr& v = p->GetPropertyValue(parms);
         return LuaObject::push(L, v);
     }
 
@@ -2955,12 +2955,7 @@ namespace NS_SLUA {
             return 1;
         }
         if (getObjCache(L, obj, "UObject")) return 1;
-        int r = pushWeakType(L, new WeakUObjectUD(ptr));
-        if (r) {
-            addLink(L, obj);
-            cacheObj(L, obj);
-        }
-        return r;
+        return push(L, obj);
     }
 
     template<typename T>

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -2384,7 +2384,7 @@ namespace NS_SLUA {
     void* checkUProperty<FEnumProperty>(lua_State* L, FProperty* prop, uint8* parms, int i, bool bForceCopy) {
         auto p = CastField<FEnumProperty>(prop);
         ensure(p);
-        auto v = (int64)LuaObject::checkValue<int>(L, i);
+        auto v = (int64)LuaObject::checkValue<int64>(L, i);
         p->CopyCompleteValue(parms, &v);
         return nullptr;
     }

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaObject.cpp
@@ -1750,7 +1750,7 @@ namespace NS_SLUA {
         ensure(p);
         auto p2 = p->GetUnderlyingProperty();
         ensure(p2);
-        int e = p2->GetSignedIntPropertyValue(parms);
+        auto e = p2->GetSignedIntPropertyValue(parms);
         return LuaObject::push(L, e);
     }
 

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
@@ -77,6 +77,7 @@ void ULuaOverrider::luaOverrideFunc(UObject* Context, FFrame& Stack, RESULT_DECL
     bool bCallFromNative = false;
     bool bContextOp = false;
     
+    FMemMark MemMark(FMemStack::Get());
     TArray<FProperty*, TMemStackAllocator<>> propertyToDestructList;
 
     if (Stack.CurrentNativeFunction)
@@ -722,6 +723,7 @@ namespace NS_SLUA
         {
             FRWScopeLock lock(classHookMutex, SLT_Write);
             UClass::ClassConstructorType *classConstructorFuncPtr = nullptr;
+            FMemMark MemMark(FMemStack::Get());
             TArray<UClass*, TMemStackAllocator<>> handleClasses;
             auto superCls = cls;
             while (classConstructorFuncPtr == nullptr && superCls)

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
@@ -8,6 +8,7 @@
 #include "UObject/Script.h"
 #include "LuaVar.h"
 #include "LuaNet.h"
+#include "UObject/Package.h"
 #include "UObject/UObjectBaseUtility.h"
 #include "UObject/UObjectThreadContext.h"
 #include "LuaOverriderInterface.h"
@@ -15,6 +16,8 @@
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "Engine/GameEngine.h"
 #include "Engine/NetDriver.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/Pawn.h"
 #include "GameFramework/InputSettings.h"
 #include "GameFramework/PlayerController.h"
 

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverrider.cpp
@@ -467,7 +467,7 @@ NS_SLUA::LuaVar* ULuaOverrider::getObjectLuaTable(const UObject* obj, NS_SLUA::l
     return nullptr;
 }
 
-ULuaOverrider::FObjectTable* ULuaOverrider::getObjectTable(const UObject* obj, slua::lua_State* L)
+ULuaOverrider::FObjectTable* ULuaOverrider::getObjectTable(const UObject* obj, NS_SLUA::lua_State* L)
 {
     if (L)
     {

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverriderInterface.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaOverriderInterface.cpp
@@ -6,9 +6,9 @@ ULuaOverriderInterface::ULuaOverriderInterface(const class FObjectInitializer& O
 {
 }
 
-NS_SLUA::LuaVar ILuaOverriderInterface::GetSelfTable() const
+NS_SLUA::LuaVar ILuaOverriderInterface::GetSelfTable(NS_SLUA::LuaState* L/* = nullptr*/) const
 {
-    NS_SLUA::LuaVar* luaSelfTable = ULuaOverrider::getObjectLuaTable(Cast<UObject>(this));
+    NS_SLUA::LuaVar* luaSelfTable = ULuaOverrider::getObjectLuaTable(Cast<UObject>(this), L ? L->getLuaState() : nullptr);
     if (luaSelfTable)
     {
         return *luaSelfTable;

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
@@ -771,7 +771,10 @@ namespace NS_SLUA {
         lua_pushstring(L, fn);
         
         if (lua_pcall(L, 1, 1, top))
-            lua_pop(L, 1);
+        {
+            lua_pop(L, 2);
+            return LuaVar();
+        }
 
         lua_remove(L, top);
 

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaState.cpp
@@ -20,7 +20,7 @@
 #include "SluaLib.h"
 #include "UObject/UObjectGlobals.h"
 #include "UObject/Package.h"
-#include "Blueprint/UserWidget.h"
+#include "Engine/GameInstance.h"
 #include "Misc/AssertionMacros.h"
 #include "Misc/SecureHash.h"
 #include "Log.h"

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/LuaWrapper.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/LuaWrapper.cpp
@@ -14,6 +14,8 @@
 #include "LuaWrapper.h"
 #include "LuaObject.h"
 #include "LuaNetSerialization.h"
+#include "UObject/Package.h"
+#include "Misc/FrameTime.h"
 
 #define SLUA_GCSTRUCT(typeName) auto flag = udptr->flag; \
                     if (udptr->parent) { \

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/PropertyUtil.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/PropertyUtil.cpp
@@ -291,6 +291,12 @@ namespace NS_SLUA {
         case EPropertyClass::Str:
             p = newProperty(owner, FStrProperty::StaticClass(), propName);
             break;
+        case EPropertyClass::Name:
+            p = newProperty(owner, FNameProperty::StaticClass(), propName);
+            break;
+        case EPropertyClass::Text:
+            p = newProperty(owner, FTextProperty::StaticClass(), propName);
+            break;
         case EPropertyClass::Object: {
             auto op = newProperty<FObjectPropertyBase>(owner, FObjectProperty::StaticClass(), propName);
             op->SetPropertyClass(proto.cls);

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/SluaLib.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/SluaLib.cpp
@@ -35,7 +35,7 @@
 #include <chrono>
 
 #include "LuaOverrider.h"
-#include "Engine/GameEngine.h"
+#include "Engine/GameInstance.h"
 
 #if UE_BUILD_DEVELOPMENT
 #include "GenericPlatform/GenericPlatformMisc.h"

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/SluaLib.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/SluaLib.cpp
@@ -335,10 +335,6 @@ namespace NS_SLUA {
                                : obj = LuaObject::checkUD<UClass>(L, 1, false);
             bIsValid = LuaObject::isUObjectValid(obj);
         }
-        else if (gud->flag&UD_WEAKUPTR) {
-            UserData<WeakUObjectUD*>* wud = (UserData<WeakUObjectUD*>*)gud;
-            bIsValid = wud->ud->isValid();
-        }
         return LuaObject::push(L, bIsValid);
     }
 

--- a/Plugins/slua_unreal/Source/slua_unreal/Private/SluaProfilerDataManager.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/SluaProfilerDataManager.cpp
@@ -6,6 +6,7 @@
 #include "LuaProfiler.h"
 #include "Serialization/MemoryReader.h"
 #include "Misc/Paths.h"
+#include "Misc/ScopedSlowTask.h"
 #include <LuaState.h>
 
 #include "HAL/RunnableThread.h"

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaClass.inl
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaClass.inl
@@ -51,32 +51,33 @@ function Class(base, static, classImplement)
         __index = class_index,
     }
 
+    local function recursiveCtor(r, impl, ...)
+        local superImpl = impl.__super_impl
+        if superImpl then
+            recursiveCtor(r, superImpl, ...)
+        end
+        local ctor = impl.ctor
+        if ctor then
+            ctor(r, ...)
+        end
+    end
+
     setmetatable(class,
         {
             __index = class_index,
 
-            __newindex = function ()
-                error("Prevent __newindex with class!")
+            __newindex = function (t, k, v)
+                error(string_format("Prevent __newindex with class! k=%s", k))
             end,
 
-            __call = function(...)
-                local r = base_mt.__call(...)
+            __call = function(_, ...)
+                local r = {}
                 setmetatable(r, instance_metatable)
-
-                if classImplement.ctor then
-                    classImplement.ctor(r, ...)
-                end
-
+                recursiveCtor(r, classImplement, ...)
                 return r
             end,
         }
     )
     return class
 end
-
-local base = {}
-setmetatable(base, {__call = function () return {} end})
-
-CBase = Class(base, nil, nil)
-
 )code";

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaDelegate.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaDelegate.h
@@ -74,7 +74,7 @@ namespace NS_SLUA {
         static int Add(lua_State* L);
         static int Remove(lua_State* L);
         static int Clear(lua_State* L);
-        static int BroadCast(lua_State* L);
+        static int Broadcast(lua_State* L);
         static int gc(lua_State* L);
     };
 

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaNet.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaNet.h
@@ -72,7 +72,7 @@ namespace NS_SLUA
         static LuaNetSerializationMap luaNetSerializationMap;
         static ObjectToLuaNetAddressMap objectToLuaNetAddressMap;
 
-        static TArray<const UClass*> luaReplicateClasses;
+        static TArray<const UClass*, TAlignedHeapAllocator<16>> luaReplicateClasses;
 
         static TMap<FString, EFunctionFlags> luaRPCTypeMap;
         static TSet<TWeakObjectPtr<UClass>> addedRPCClasses;

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaObject.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaObject.h
@@ -377,11 +377,7 @@ namespace NS_SLUA {
 
         // check UObject is valid
         static bool isUObjectValid(UObject* obj) {
-#if ENGINE_MAJOR_VERSION >= 5
-            return IsValid(obj);
-#else
-            return obj && !obj->IsUnreachable() && !obj->IsPendingKill();
-#endif
+            return IsValid(obj) && !obj->IsUnreachable();
         }
 
         static inline bool isBinStringProperty(FProperty* inner)

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaObject.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaObject.h
@@ -618,7 +618,7 @@ namespace NS_SLUA {
             if(checkfree && !typearg)
                 luaL_error(L,"expect userdata at %d, if you passed an UObject, maybe it's unreachable",p);
 
-            if (LuaObject::isBaseTypeOf(L, typearg, TypeName<T>::value().c_str())) {
+            if (typearg && LuaObject::isBaseTypeOf(L, typearg, TypeName<T>::value().c_str())) {
                 UserData<T*> *udptr = reinterpret_cast<UserData<T*>*>(lua_touserdata(L, p));
                 CHECK_UD_VALID(udptr);
                 return udptr->ud;

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/LuaOverriderInterface.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/LuaOverriderInterface.h
@@ -3,6 +3,7 @@
 #include "LuaCppBindingPost.h"
 #include "UObject/Interface.h"
 #include "LuaObject.h"
+#include "LuaState.h"
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "LuaOverriderInterface.generated.h"
 
@@ -20,7 +21,7 @@ public:
     UFUNCTION(BlueprintNativeEvent)
         FString GetLuaFilePath() const;
 
-    NS_SLUA::LuaVar GetSelfTable() const;
+    NS_SLUA::LuaVar GetSelfTable(NS_SLUA::LuaState* L = nullptr) const;
 
     virtual void PostLuaHook();
 
@@ -32,15 +33,20 @@ public:
             return getFromTableIndex<NS_SLUA::LuaVar>(L, selfTable, FunctionName);
         }
 #endif
-        if (!FuncMap.Contains(FunctionName))
+        auto luaFuncPtr = FuncMap.Find(FunctionName);
+        if (!luaFuncPtr)
         {
             return FuncMap.Add(FunctionName, getFromTableIndex<NS_SLUA::LuaVar>(L, selfTable, FunctionName));
         }
-        return FuncMap[FunctionName];
+        if (L != nullptr && luaFuncPtr->getState() != L)
+        {
+            return getFromTableIndex<NS_SLUA::LuaVar>(L, selfTable, FunctionName);
+        }
+        return *luaFuncPtr;
     }
 
     bool IsLuaFunctionExist(const FString& FunctionName) {
-        const NS_SLUA::LuaVar selfTable = GetSelfTable();
+        const NS_SLUA::LuaVar selfTable = GetSelfTable(nullptr);
         if (!selfTable.isValid() || !selfTable.isTable()) {
             return false;
         }
@@ -50,37 +56,42 @@ public:
 
     template<class RET, class ...ARGS>
     RET CallLuaFunction(const FString& FunctionName, ARGS&& ...Args) {
-        NS_SLUA::LuaVar selfTable = GetSelfTable();
-        if (!selfTable.isValid() || !selfTable.isTable()) {
-            NS_SLUA::Log::Error("Lua module not assign to UObject[%s]", TCHAR_TO_UTF8(*Cast<UObject>(this)->GetName()));
-            return RET();
-        }
-
-        NS_SLUA::LuaVar ret = GetCachedLuaFunc(nullptr, selfTable, FunctionName).call(selfTable, std::forward<ARGS>(Args)...);
-        if (ret.isValid()) {
-            return ret.castTo<RET>();
-        }
-        else {
-            NS_SLUA::Log::Error("Type mismatch or have no return value! ObjectName: [%s], FunctionName[%s]",
-                TCHAR_TO_UTF8(*Cast<UObject>(this)->GetName()), TCHAR_TO_UTF8(*FunctionName));
-            return RET();
-        }
+        return Call<RET>(false, nullptr, FunctionName, std::forward<ARGS>(Args)...);
     }
-
 
     template<class ...ARGS>
     void CallLuaFunction(const FString& FunctionName, ARGS&& ...Args) {
-        Call<void>(false, FunctionName, std::forward<ARGS>(Args)...);
+        Call<void>(false, nullptr, FunctionName, std::forward<ARGS>(Args)...);
     }
 
     template<class RET, class ...ARGS>
     RET CallLuaFunctionIfExist(const FString& FunctionName, ARGS&& ...Args) {
-        return Call<RET>(true, FunctionName, std::forward<ARGS>(Args)...);
+        return Call<RET>(true, nullptr, FunctionName, std::forward<ARGS>(Args)...);
     }
     
     template<class ...ARGS>
     void CallLuaFunctionIfExist(const FString& FunctionName, ARGS&& ...Args) {
-        Call<void>(true, FunctionName, std::forward<ARGS>(Args)...);
+        Call<void>(true, nullptr, FunctionName, std::forward<ARGS>(Args)...);
+    }
+
+    template<class RET, class ...ARGS>
+    RET CallLuaFunctionWithContext(const UWorld* World, const FString& FunctionName, ARGS&& ...Args) {
+        return Call<RET>(false, World, FunctionName, std::forward<ARGS>(Args)...);
+    }
+
+    template<class ...ARGS>
+    void CallLuaFunctionWithContext(const UWorld* World, const FString& FunctionName, ARGS&& ...Args) {
+        Call<void>(false, World, FunctionName, std::forward<ARGS>(Args)...);
+    }
+
+    template<class RET, class ...ARGS>
+    RET CallLuaFunctionIfExistWithContext(const UWorld* World, const FString& FunctionName, ARGS&& ...Args) {
+        return Call<RET>(true, World, FunctionName, std::forward<ARGS>(Args)...);
+    }
+    
+    template<class ...ARGS>
+    void CallLuaFunctionIfExistWithContext(const UWorld* World, const FString& FunctionName, ARGS&& ...Args) {
+        Call<void>(true, World, FunctionName, std::forward<ARGS>(Args)...);
     }
 
     template<typename R, typename T>
@@ -112,14 +123,15 @@ public:
 
 private:
     template<class RET, class ...ARGS>
-    RET Call(bool checkExist, const FString& FunctionName, ARGS&& ...Args) {
-        auto selfTable = GetSelfTable();
+    RET Call(bool checkExist, const UWorld* World, const FString& FunctionName, ARGS&& ...Args) {
+        auto LS = World ? NS_SLUA::LuaState::get(World->GetGameInstance()) : nullptr;
+        auto selfTable = GetSelfTable(LS);
         if (!checkExist && (!selfTable.isValid() || !selfTable.isTable())) {
             NS_SLUA::Log::Error("Lua module not assign to UObject[%s]", TCHAR_TO_UTF8(*Cast<UObject>(this)->GetName()));
             return RET();
         }
 
-        const NS_SLUA::LuaVar& Func = GetCachedLuaFunc(nullptr, selfTable, FunctionName);
+        const NS_SLUA::LuaVar& Func = GetCachedLuaFunc(LS ? LS->getLuaState() : nullptr, selfTable, FunctionName);
         if (!checkExist)
         {
             NS_SLUA::LuaVar ret = Func.call(selfTable, std::forward<ARGS>(Args)...);

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/ProfileDataDefine.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/ProfileDataDefine.h
@@ -104,10 +104,10 @@ struct SLUA_UNREAL_API FProfileNameSet
         Ar << profileNameSet.indexSet;
         if (Ar.IsLoading())
         {
-            auto& stringToIndex = profileNameSet.stringToIndex;
+            auto& strToIndex = profileNameSet.stringToIndex;
             for (auto iter = profileNameSet.indexToString.CreateConstIterator(); iter; ++iter)
             {
-                stringToIndex.Emplace(iter.Value(), iter.Key());
+                strToIndex.Emplace(iter.Value(), iter.Key());
             }
         }
         profileNameSet.increaseString.Empty();

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/SluaMicro.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/SluaMicro.h
@@ -5,6 +5,10 @@
     #undef G
 #endif
 
+#ifndef LUA_VERSION_RELEASE_NUM
+#define LUA_VERSION_RELEASE_NUM (LUA_VERSION_NUM * 100 + 0)
+#endif
+
 #include "CoreMinimal.h"
 #include "UObject/CoreNative.h"
 #include "Runtime/Launch/Resources/Version.h"

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/SluaUtil.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/SluaUtil.h
@@ -163,13 +163,13 @@ namespace NS_SLUA {
 
         friend int32 GetTypeHash(const SimpleString& simpleString)
         {
-            auto &data = simpleString.data;
-            uint32 Len = data.Num() - 1;
+            auto &strData = simpleString.data;
+            uint32 Len = strData.Num() - 1;
 		    uint32 H = Seed ^ Len;
 		    uint32 Step = (Len >> 2) + 1;
 		    for (; Len >= Step; Len -= Step)
 		    {
-		        H ^= (H << 5) + (H >> 2) + TChar<ANSICHAR>::ToUpper(data[Len - 1]);
+		        H ^= (H << 5) + (H >> 2) + TChar<ANSICHAR>::ToUpper(strData[Len - 1]);
 		    }
 
             return H;

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/SluaUtil.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/SluaUtil.h
@@ -16,6 +16,7 @@
 #include <functional>
 #include <string.h>
 #include "Layout/Margin.h"
+#include "Layout/Geometry.h"
 #include "Styling/SlateColor.h"
 #include "Styling/SlateBrush.h"
 #include "Widgets/Layout/Anchors.h"

--- a/Plugins/slua_unreal/Source/slua_unreal/Public/slua.h
+++ b/Plugins/slua_unreal/Source/slua_unreal/Public/slua.h
@@ -27,7 +27,3 @@
 #include "LuaDelegate.h"
 #include "LuaCppBinding.h"
 #include "LuaCppBindingPost.h"
-
-#ifndef LUA_VERSION_RELEASE_NUM
-#define LUA_VERSION_RELEASE_NUM (LUA_VERSION_NUM * 100 + 0)
-#endif

--- a/Plugins/slua_unreal/Source/slua_unreal/slua_unreal.Build.cs
+++ b/Plugins/slua_unreal/Source/slua_unreal/slua_unreal.Build.cs
@@ -28,8 +28,8 @@ public class slua_unreal : ModuleRules
 #endif
         bEnableUndefinedIdentifierWarnings = false;
 
-        var externalSource = Path.Combine(ModuleDirectory, "../../External");
-        var externalLib = Path.Combine(ModuleDirectory, "../../Library");
+        var externalSource = Path.Combine(PluginDirectory, "External");
+        var externalLib = Path.Combine(PluginDirectory, "Library");
 
         PublicIncludePaths.AddRange(
             new string[] {

--- a/Source/democpp/SluaTestCase.cpp
+++ b/Source/democpp/SluaTestCase.cpp
@@ -16,6 +16,7 @@
 #include "UObject/UObjectGlobals.h"
 #include "UObject/Package.h"
 #include "Misc/AssertionMacros.h"
+#include "Engine/HitResult.h"
 #include "HttpModule.h"
 #include "Interfaces/IHttpRequest.h"
 #include "Interfaces/IHttpResponse.h"


### PR DESCRIPTION
bug fixes：
1. UE5下LuaObject::isUObjectValid补上IsUnreachable的判断，否则会导致UObject对应的UClass野指针访问崩溃
2. 修复一些Android下UE5.4的头文件include编译错误和其他的编译错误
3. 修复require模块失败时栈维护错误的bug
4. 修复LuaObject::checkUD时typearg可能为空导致崩溃

features：
1. Enum类型支持64位
2. lua类的ctor构造函数，第一个参数不再需要写一个冗余的SelfType参数
3. 改变FWeakObjetPtr的获取机制为直接返回UObject类型，删除WeakUObjectUD结构
4. [CallLuaFunction](https://github.com/Tencent/sluaunreal/commit/7496ba517de296cccca052ebc58b8bd7120591b1)添加WithContext的支持（用于编辑器下多虚拟机的正确运行）
5. [LuaMultiDelegate::BroadCast 变为 LuaMultiDelegate::Broadcast.](https://github.com/Tencent/sluaunreal/commit/0f89339a8a13125f211794d230f220ccb6276e35)
6. [PropertyProto::createProperty添加支持FName/Text类型]