### PR TITLE
fixed ue4.26 bad dependency on Oodle, switch to Zlib， also 4.26 has n…

### DIFF
--- a/Plugins/slua_unreal/Source/slua_unreal/Private/SluaProfilerDataManager.cpp
+++ b/Plugins/slua_unreal/Source/slua_unreal/Private/SluaProfilerDataManager.cpp
@@ -693,6 +693,8 @@ void FProfileDataProcessRunnable::LoadData(const FString& filePath, int& inCpuVi
             ar->Serialize(compressedBuffer, compressedSize);
 #if (ENGINE_MINOR_VERSION<=21) && (ENGINE_MAJOR_VERSION==4)
             FCompression::UncompressMemory(COMPRESS_ZLIB, uncompressedBuffer.GetData(), uncompressedSize, compressedBuffer, compressedSize);
+#elif (ENGINE_MINOR_VERSION<=26) && (ENGINE_MAJOR_VERSION==4)
+            FCompression::UncompressMemory(NAME_Zlib, uncompressedBuffer.GetData(), uncompressedSize, compressedBuffer, compressedSize);
 #else
             FCompression::UncompressMemory(NAME_Oodle, uncompressedBuffer.GetData(), uncompressedSize, compressedBuffer, compressedSize);
 #endif
@@ -927,12 +929,16 @@ void FProfileDataProcessRunnable::SerializeCompreesedDataToFile(FArchive& ar)
     int32 uncompressedSize = dataToCompress.Num();
 #if (ENGINE_MINOR_VERSION<=21) && (ENGINE_MAJOR_VERSION==4)
     int32 compressedSize = FCompression::CompressMemoryBound(COMPRESS_ZLIB, uncompressedSize);
+#elif (ENGINE_MINOR_VERSION<=26) && (ENGINE_MAJOR_VERSION==4)
+    int32 compressedSize = FCompression::CompressMemoryBound(NAME_Zlib, uncompressedSize);
 #else
     int32 compressedSize = FCompression::CompressMemoryBound(NAME_Oodle, uncompressedSize);
 #endif
     auto compressedBuffer = (uint8*)FMemory::Malloc(compressedSize);
 #if (ENGINE_MINOR_VERSION<=21) && (ENGINE_MAJOR_VERSION==4)
     FCompression::CompressMemory(COMPRESS_ZLIB, compressedBuffer, compressedSize, dataToCompress.GetData(), uncompressedSize);
+#elif (ENGINE_MINOR_VERSION<=26) && (ENGINE_MAJOR_VERSION==4)
+    FCompression::CompressMemory(NAME_Zlib, compressedBuffer, compressedSize, dataToCompress.GetData(), uncompressedSize);
 #else
     FCompression::CompressMemory(NAME_Oodle, compressedBuffer, compressedSize, dataToCompress.GetData(), uncompressedSize);
 #endif


### PR DESCRIPTION
4.26暂未引入Oodle, 将slua插件中压缩插件换为Zlib，[issue 630#](https://github.com/Tencent/sluaunreal/issues/630)
另外demo项目中 SluaTestCase.cpp 引入 HitResult.h，4.26公版引擎中没有；本PR没改这一块