### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/Plugins/slua_unreal/External/lua/ldebug.cpp
+++ b/Plugins/slua_unreal/External/lua/ldebug.cpp
@@ -654,8 +654,11 @@ l_noret luaG_runerror (lua_State *L, const char *fmt, ...) {
   va_start(argp, fmt);
   msg = luaO_pushvfstring(L, fmt, argp);  /* format message */
   va_end(argp);
-  if (isLua(ci))  /* if Lua function, add source:line information */
+  if (isLua(ci)) {  /* if Lua function, add source:line information */
     luaG_addinfo(L, msg, ci_func(ci)->p->source, currentline(ci));
+    setobjs2s(L, L->top - 2, L->top - 1);  /* remove 'msg' from the stack */
+    L->top--;
+  }
   luaG_errormsg(L);
 }
 


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a clone function luaG_runerror() in `Plugins/slua_unreal/External/lua/ldebug.cpp` sourced from [lua/lua](https://github.com/lua/lua). This issue, originally reported in [CVE-2022-33099](https://nvd.nist.gov/vuln/detail/CVE-2022-33099), was resolved in the repository via this commit https://github.com/lua/lua/commit/42d40581dd919fb134c07027ca1ce0844c670daf.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!